### PR TITLE
Improve docs styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "lodash": "^4.17.10",
     "make-dir": "^1.3.0",
     "moment": "^2.22.2",
-    "pascal-case": "^2.0.1",
     "pify": "^3.0.0",
     "prettier": "1.13.7",
     "prismjs": "^1.15.0",

--- a/src/components/code-snippet/code-snippet.js
+++ b/src/components/code-snippet/code-snippet.js
@@ -76,35 +76,21 @@ const defaultTheme = `
 // Theme cache, used to prevent the creation of multiple <style> elements with the same content.
 const injectedThemes = [];
 
-/**
- * @param {string} code - Raw (unhighlighted) code. When the user clicks a copy button, this is
- *   what they'll get. If no `highlightedCode` is provided, `code` is displayed.
- * @param {string} [highlightedCode] - The HTML output of running code through a syntax highlighter.
- *   If this is not provided, `code` is displayed, instead.
- *   The default theme CSS assumes the highlighter is [`highlight.js`](https://github.com/isagalaev/highlight.js).
- *   If you are using another highlighter, provide your own theme.
- * @param {Array<Array<number>>} [copyRanges] - Specific line ranges that should be independently
- *   copiable. Each range is a two-value array, consisting of the starting and ending line.
- *   If this is not provided, the entire snippet is copiable.
- * @param {number} [maxHeight] - A maximum height for the snippet. If the code exceeds this height,
- *   the snippet will scroll internally.
- * @param {Function} [onCopy] - A callback that is invoked when the snippet (or a chunk of the snippet)
- *   is copied. If `copyRanges` are provided, the callback is passed the index (0-based) of the
- *   chunk that was copied.
- * @param {string} [highlightThemeCss] - CSS that styles the highlighted code.
- *   The default theme is a [`highlight.js` theme](https://highlightjs.readthedocs.io/en/latest/style-guide.html#defining-a-theme)
- *   theme. It is the dark theme used on mapbox.com's installation flow.
- * @param {number} [characterWidth=7.225] - The width of a character in the theme's monospace font, used for
- *   indentation. If you use a font or font-size different than the default theme, you may need to change this value.
- */
 export default class CodeSnippet extends React.PureComponent {
   static propTypes = {
+    /** Raw (unhighlighted) code. When the user clicks a copy button, this is what they'll get. If no `highlightedCode` is provided, `code` is displayed. */
     code: PropTypes.string.isRequired,
+    /** The HTML output of running code through a syntax highlighter. If this is not provided, `code` is displayed, instead. The default theme CSS assumes the highlighter is [`highlight.js`](https://github.com/isagalaev/highlight.js). If you are using another highlighter, provide your own theme. */
     highlightedCode: PropTypes.string,
+    /** Specific line ranges that should be independently copiable. Each range is a two-value array, consisting of the starting and ending line. If this is not provided, the entire snippet is copiable. */
     copyRanges: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+    /** A maximum height for the snippet. If the code exceeds this height, the snippet will scroll internally. */
     maxHeight: PropTypes.number,
+    /** A callback that is invoked when the snippet (or a chunk of the snippet) is copied. If `copyRanges` are provided, the callback is passed the index (0-based) of the chunk that was copied. */
     onCopy: PropTypes.func,
+    /** CSS that styles the highlighted code. The default theme is a [`highlight.js` theme](https://highlightjs.readthedocs.io/en/latest/style-guide.html#defining-a-theme) theme. It is the dark theme used on mapbox.com's installation flow. */
     highlightThemeCss: PropTypes.string,
+    /** The width of a character in the theme's monospace font, used for indentation. If you use a font or font-size different than the default theme, you may need to change this value. */
     characterWidth: PropTypes.number
   };
 

--- a/src/docs/app.js
+++ b/src/docs/app.js
@@ -5,33 +5,23 @@ import Sidebar from './components/sidebar';
 
 export default class App extends React.Component {
   render() {
-    const componentEls = components.map(component => {
-      return <ComponentSection key={component.name} data={component} />;
+    const componentEls = components.map((component, index) => {
+      let containerClasses = 'pb60 border-b border--darken10';
+      if (index !== 0) {
+        containerClasses += ' mt36';
+      }
+      return (
+        <div key={component.name} className={containerClasses}>
+          <ComponentSection data={component} />
+        </div>
+      );
     });
     return (
       <div>
-        <div className="fixed top left bottom w300 px12 py12 scroll-styled scroll-auto">
-          <h1 className="txt-bold txt-h4 txt-fancy">Mr. UI</h1>
-          <div className="mb12">
-            <a
-              className="link txt-s"
-              href="https://github.com/mapbox/mr-ui"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span className="flex-parent flex-parent--center-cross">
-                <span className="flex-child flex-child--no-shrink mr6">
-                  <svg className="icon">
-                    <use xlinkHref="#icon-github" />
-                  </svg>
-                </span>
-                <span className="flex-child">GitHub repo</span>
-              </span>
-            </a>
-          </div>
+        <div className="fixed top left bottom w300 py24 px24 scroll-styled scroll-auto">
           <Sidebar />
         </div>
-        <div className="ml300 px12">{componentEls}</div>
+        <div className="ml300 px24">{componentEls}</div>
       </div>
     );
   }

--- a/src/docs/components/component-example.js
+++ b/src/docs/components/component-example.js
@@ -11,29 +11,59 @@ export default class ComponentExample extends React.Component {
   };
 
   renderCode() {
-    if (!this.state.showCode) return null;
+    if (!this.state.showCode) {
+      return null;
+    }
     return (
-      <pre className="mt6 language-js">
+      <pre className="my0 round-tl pre language-jsx">
         <code dangerouslySetInnerHTML={{ __html: this.props.code }} />
       </pre>
     );
   }
 
   render() {
-    const { props } = this;
+    const { props, state } = this;
     return (
       <div>
-        <div className="mb6 prose">{props.description}</div>
-        <div className="border round border--gray-light border--dash">
-          {React.createElement(props.exampleModule.default)}
+        <div className="flex-parent flex-parent--end-cross">
+          <div className="flex-child flex-child--grow pb6">
+            {props.description}
+          </div>
+          <div className="flex-child flex-child--no-shrink w120">
+            <div className="flex-parent flex-parent--end-main">
+              <div className="flex-child">
+                <ToggleCodeButton
+                  onClick={this.toggleCode}
+                  codeIsVisible={state.showCode}
+                />
+              </div>
+            </div>
+          </div>
         </div>
-        <div className="mt6">
-          <button className="btn btn--s" onClick={this.toggleCode}>
-            Toggle code
-          </button>
-          {this.renderCode()}
+        {this.renderCode()}
+        <div className="border border--gray-light px24 py24">
+          {React.createElement(props.exampleModule.default)}
         </div>
       </div>
     );
   }
+}
+
+function ToggleCodeButton(props) {
+  const text = props.codeIsVisible ? 'Hide code' : 'Show code';
+  return (
+    <button
+      className="block btn btn--s btn--gray unround-b round-t"
+      onClick={props.onClick}
+    >
+      <span className="flex-parent flex-parent--center-cross">
+        <span className="flex-child">
+          <svg className="icon">
+            <use xlinkHref="#icon-code" />
+          </svg>
+        </span>
+        <span className="ml6 flex-child">{text}</span>
+      </span>
+    </button>
+  );
 }

--- a/src/docs/components/sidebar.js
+++ b/src/docs/components/sidebar.js
@@ -16,8 +16,18 @@ export default class Sidebar extends React.Component {
       );
     });
     return (
-      <div className="pt24 txt-s">
-        <ul>{componentLinks}</ul>
+      <div>
+        <a
+          className="link"
+          href="https://github.com/mapbox/mr-ui"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <h1 className="txt-bold txt-h3 txt-mono">Mr UI</h1>
+        </a>
+        <div className="pt12 txt-s">
+          <ul>{componentLinks}</ul>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
There's a lot of cleaning up that needs to be done in the documentation. I thought I'd start by trying to establish a nicer style.

Here are some highlights from my flailing attempt, along with screenshots with garish pink pointers:

- Link to the Mr. UI repo.
- Padding around the rendered examples (no need to show exactly how they lay out, as in the test cases).
- A little example-code-toggling button that looks kind of tabby.
- Props are in a table.
- Purple "Required" badge.
- "Default value" is beneath the description because it doesn't really need its own column, I thought.
- Prism is highlighting JSX nicely.
- Light gray lines between sections!

![2018-07-26 at 5 35 pm](https://user-images.githubusercontent.com/628431/43295605-df64d2d2-90fa-11e8-9145-d3d9f1fb0c3a.png)

![2018-07-26 at 5 36 pm](https://user-images.githubusercontent.com/628431/43295606-df7c8c92-90fa-11e8-86e4-685503c99224.png)

@danswick for review, please. After this, we can do a round of content & example cleaning before publishing the site.

@dasulit ... I hope you're doing well ...