### PR TITLE
MbxUnderlineTabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@mapbox/query-selector-contains-node": "^1.0.0",
+    "classnames": "^2.2.6",
     "clipboard": "^2.0.0",
     "debounce": "^1.1.0",
     "focus-trap": "^2.3.0",

--- a/src/components/mbx-icon-text/mbx-icon-text.js
+++ b/src/components/mbx-icon-text/mbx-icon-text.js
@@ -43,7 +43,7 @@ class MbxIconText extends React.Component {
 
 MbxIconText.propTypes = {
   /**
-   * The text. A string is recommended, but you can put an element in here if you think it's right.
+   * The text. A string is recommended, but you can put an element in here if you think it's right. If you do, it should be inline-level, using `<span>`s instead of `<div>`s.
    */
   children: PropTypes.node.isRequired,
   /**

--- a/src/components/mbx-underline-tabs/__tests__/__snapshots__/mbx-underline-tabs.test.js.snap
+++ b/src/components/mbx-underline-tabs/__tests__/__snapshots__/mbx-underline-tabs.test.js.snap
@@ -298,7 +298,7 @@ exports[`large links with icons renders as expected 1`] = `
     </a>
   </li>
   <li
-    className="flex-child ml24"
+    className="flex-child ml24 ml36-mxl"
     key="B"
   >
     <a
@@ -324,7 +324,7 @@ exports[`large links with icons renders as expected 1`] = `
     </a>
   </li>
   <li
-    className="flex-child ml24"
+    className="flex-child ml24 ml36-mxl"
     key="C"
   >
     <a
@@ -383,7 +383,7 @@ exports[`large renders as expected 1`] = `
     </button>
   </li>
   <li
-    className="flex-child ml24"
+    className="flex-child ml24 ml36-mxl"
     key="B"
   >
     <button
@@ -409,7 +409,7 @@ exports[`large renders as expected 1`] = `
     </button>
   </li>
   <li
-    className="flex-child ml24"
+    className="flex-child ml24 ml36-mxl"
     key="C"
   >
     <button

--- a/src/components/mbx-underline-tabs/__tests__/__snapshots__/mbx-underline-tabs.test.js.snap
+++ b/src/components/mbx-underline-tabs/__tests__/__snapshots__/mbx-underline-tabs.test.js.snap
@@ -1,0 +1,617 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ID labels and a disabled item renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-bold txt-s"
+>
+  <li
+    className="flex-child"
+    key="ant"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="ant"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 42,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Ant
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24 ml36-mxl"
+    key="bug"
+  >
+    <button
+      className="block relative color-gray-light cursor-default"
+      data-test="bug"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 42,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Bug
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24 ml36-mxl"
+    key="cat"
+  >
+    <button
+      className="block relative color-gray-dark cursor-default"
+      data-test="cat"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 42,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Cat
+        </span>
+        <span
+          className="absolute bottom left right border-b border-b--2"
+        />
+      </span>
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`customized renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-xs"
+>
+  <li
+    className="flex-child"
+    key="A"
+  >
+    <button
+      className="block relative color-pink cursor-default"
+      data-test="A"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 36,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter A
+        </span>
+        <span
+          className="absolute bottom left right border-b"
+        />
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml12"
+    key="B"
+  >
+    <button
+      className="block relative color-purple color-pink-on-hover"
+      data-test="B"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 36,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter B
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml12"
+    key="C"
+  >
+    <button
+      className="block relative color-purple color-pink-on-hover"
+      data-test="C"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 36,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter C
+        </span>
+      </span>
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`defaults renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-bold txt-s"
+>
+  <li
+    className="flex-child"
+    key="A"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="A"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 42,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter A
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24 ml36-mxl"
+    key="B"
+  >
+    <button
+      className="block relative color-gray-dark cursor-default"
+      data-test="B"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 42,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter B
+        </span>
+        <span
+          className="absolute bottom left right border-b border-b--2"
+        />
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24 ml36-mxl"
+    key="C"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="C"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 42,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter C
+        </span>
+      </span>
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`large links with icons renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-bold"
+>
+  <li
+    className="flex-child"
+    key="A"
+  >
+    <a
+      className="block relative color-gray-dark cursor-default"
+      data-test="A"
+      href="#"
+      onClick={[Function]}
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 48,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          MbxIconText
+        </span>
+        <span
+          className="absolute bottom left right border-b border-b--2"
+        />
+      </span>
+    </a>
+  </li>
+  <li
+    className="flex-child ml24"
+    key="B"
+  >
+    <a
+      className="block relative color-gray color-blue-on-hover"
+      data-test="B"
+      href="#"
+      onClick={[Function]}
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 48,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          MbxIconText
+        </span>
+      </span>
+    </a>
+  </li>
+  <li
+    className="flex-child ml24"
+    key="C"
+  >
+    <a
+      className="block relative color-gray color-blue-on-hover"
+      data-test="C"
+      href="#"
+      onClick={[Function]}
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 48,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          MbxIconText
+        </span>
+      </span>
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`large renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-bold"
+>
+  <li
+    className="flex-child"
+    key="A"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="A"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 48,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter A
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24"
+    key="B"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="B"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 48,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter B
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24"
+    key="C"
+  >
+    <button
+      className="block relative color-gray-dark cursor-default"
+      data-test="C"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 48,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter C
+        </span>
+        <span
+          className="absolute bottom left right border-b border-b--2"
+        />
+      </span>
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`overlap renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-bold txt-s"
+>
+  <li
+    className="flex-child"
+    key="A"
+  >
+    <button
+      className="block relative mb-neg1 mt-neg1 color-gray color-blue-on-hover"
+      data-test="A"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 44,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter A
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24 ml36-mxl"
+    key="B"
+  >
+    <button
+      className="block relative mb-neg1 mt-neg1 color-gray-dark cursor-default"
+      data-test="B"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 44,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter B
+        </span>
+        <span
+          className="absolute bottom left right border-b border-b--2"
+        />
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml24 ml36-mxl"
+    key="C"
+  >
+    <button
+      className="block relative mb-neg1 mt-neg1 color-gray color-blue-on-hover"
+      data-test="C"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 44,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter C
+        </span>
+      </span>
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`small renders as expected 1`] = `
+<ul
+  className="flex-parent txt-nowrap unselectable txt-bold txt-xs"
+>
+  <li
+    className="flex-child"
+    key="A"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="A"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 36,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter A
+        </span>
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml12"
+    key="B"
+  >
+    <button
+      className="block relative color-gray-dark cursor-default"
+      data-test="B"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 36,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter B
+        </span>
+        <span
+          className="absolute bottom left right border-b"
+        />
+      </span>
+    </button>
+  </li>
+  <li
+    className="flex-child ml12"
+    key="C"
+  >
+    <button
+      className="block relative color-gray color-blue-on-hover"
+      data-test="C"
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="block relative flex-parent flex-parent--center-cross"
+        style={
+          Object {
+            "height": 36,
+          }
+        }
+      >
+        <span
+          className="flex-child"
+        >
+          Letter C
+        </span>
+      </span>
+    </button>
+  </li>
+</ul>
+`;

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MbxUnderlineTabs from '../mbx-underline-tabs';
+import safeSpy from '../../../test-utils/safe-spy';
+
+const testCases = {};
+
+class ButtonsDemo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      active: 'A'
+    };
+
+    this.changeActive = nextActive => {
+      this.setState({ active: nextActive });
+    };
+  }
+
+  render() {
+    const items = [
+      {
+        id: 'A',
+        label: 'Letter A'
+      },
+      {
+        id: 'B',
+        label: 'Letter B'
+      },
+      {
+        id: 'C',
+        label: 'Letter C'
+      }
+    ];
+    return (
+      <div className="px12 py12">
+        <div className="border-b border--gray-light">
+          <MbxUnderlineTabs
+            items={items}
+            active={this.state.active}
+            onChange={this.changeActive}
+            size={this.props.size}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+ButtonsDemo.propTypes = {
+  size: PropTypes.string
+};
+
+testCases.interactive = {
+  description: 'interactive',
+  element: <ButtonsDemo />
+};
+
+testCases.small = {
+  description: 'small',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'A',
+        label: 'Letter A'
+      },
+      {
+        id: 'B',
+        label: 'Letter B'
+      },
+      {
+        id: 'C',
+        label: 'Letter C'
+      }
+    ],
+    active: 'B',
+    onChange: safeSpy(),
+    size: 'small'
+  }
+};
+
+testCases.large = {
+  description: 'large',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'A',
+        label: 'Letter A'
+      },
+      {
+        id: 'B',
+        label: 'Letter B'
+      },
+      {
+        id: 'C',
+        label: 'Letter C'
+      }
+    ],
+    active: 'C',
+    onChange: safeSpy(),
+    size: 'large'
+  }
+};
+
+testCases.dim = {
+  description: 'dim',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'A',
+        label: 'Letter A'
+      },
+      {
+        id: 'B',
+        label: 'Letter B'
+      },
+      {
+        id: 'C',
+        label: 'Letter C'
+      }
+    ],
+    active: 'A',
+    onChange: safeSpy(),
+    size: 'small',
+    activeColor: 'gray-dark',
+    inactiveColor: 'gray'
+  }
+};
+
+export { testCases };

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
@@ -56,6 +56,53 @@ testCases.interactive = {
   element: <ButtonsDemo />
 };
 
+testCases.defaults = {
+  description: 'defaults',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'A',
+        label: 'Letter A'
+      },
+      {
+        id: 'B',
+        label: 'Letter B'
+      },
+      {
+        id: 'C',
+        label: 'Letter C'
+      }
+    ],
+    active: 'B',
+    onChange: safeSpy()
+  }
+};
+
+testCases.noOverlap = {
+  description: 'no overlap',
+  component: MbxUnderlineTabs,
+  props: {
+    overlapBorder: false,
+    items: [
+      {
+        id: 'A',
+        label: 'Letter A'
+      },
+      {
+        id: 'B',
+        label: 'Letter B'
+      },
+      {
+        id: 'C',
+        label: 'Letter C'
+      }
+    ],
+    active: 'B',
+    onChange: safeSpy()
+  }
+};
+
 testCases.small = {
   description: 'small',
   component: MbxUnderlineTabs,

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import MbxIconText from '../../mbx-icon-text';
 import MbxUnderlineTabs from '../mbx-underline-tabs';
 import safeSpy from '../../../test-utils/safe-spy';
 
 const testCases = {};
 
-class ButtonsDemo extends React.Component {
+class InteractiveDemo extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -48,13 +49,13 @@ class ButtonsDemo extends React.Component {
   }
 }
 
-ButtonsDemo.propTypes = {
+InteractiveDemo.propTypes = {
   size: PropTypes.string
 };
 
 testCases.interactive = {
   description: 'interactive',
-  element: <ButtonsDemo />
+  element: <InteractiveDemo />
 };
 
 testCases.manyItems = {
@@ -199,24 +200,24 @@ testCases.large = {
   }
 };
 
-testCases.largeLinks = {
-  description: 'large links',
+testCases.largeLinksIcons = {
+  description: 'large links with icons',
   component: MbxUnderlineTabs,
   props: {
     items: [
       {
         id: 'A',
-        label: 'Hash',
+        label: <MbxIconText iconBefore="floppy">Disk</MbxIconText>,
         href: '#'
       },
       {
         id: 'B',
-        label: 'Browns',
+        label: <MbxIconText iconBefore="alert">Alert</MbxIconText>,
         href: '#'
       },
       {
         id: 'C',
-        label: 'Breakfast',
+        label: <MbxIconText iconBefore="book">Book</MbxIconText>,
         href: '#'
       }
     ],

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
@@ -127,11 +127,11 @@ testCases.defaults = {
   }
 };
 
-testCases.noOverlap = {
-  description: 'no overlap',
+testCases.overlap = {
+  description: 'overlap',
   component: MbxUnderlineTabs,
   props: {
-    overlapBorder: false,
+    overlapBorder: true,
     items: [
       {
         id: 'A',
@@ -251,6 +251,27 @@ testCases.customized = {
     inactiveColor: 'purple',
     hoverColor: 'pink',
     bold: false
+  }
+};
+
+testCases.idLabelsAndDisabledItem = {
+  description: 'ID labels and a disabled item',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'ant'
+      },
+      {
+        id: 'bug',
+        disabled: true
+      },
+      {
+        id: 'cat'
+      }
+    ],
+    active: 'cat',
+    onChange: safeSpy()
   }
 };
 

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs-test-cases.js
@@ -40,6 +40,7 @@ class ButtonsDemo extends React.Component {
             active={this.state.active}
             onChange={this.changeActive}
             size={this.props.size}
+            overlapBorder={true}
           />
         </div>
       </div>
@@ -54,6 +55,53 @@ ButtonsDemo.propTypes = {
 testCases.interactive = {
   description: 'interactive',
   element: <ButtonsDemo />
+};
+
+testCases.manyItems = {
+  description: 'many items',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'A',
+        label: 'Porcupine'
+      },
+      {
+        id: 'B',
+        label: 'Walrus'
+      },
+      {
+        id: 'C',
+        label: 'Eggplant'
+      },
+      {
+        id: 'D',
+        label: 'Gorilla'
+      },
+      {
+        id: 'E',
+        label: 'Spoon'
+      },
+      {
+        id: 'F',
+        label: 'Horseman'
+      },
+      {
+        id: 'G',
+        label: 'Cloud'
+      },
+      {
+        id: 'H',
+        label: 'Sun'
+      },
+      {
+        id: 'I',
+        label: 'Sand'
+      }
+    ],
+    active: 'C',
+    onChange: safeSpy()
+  }
 };
 
 testCases.defaults = {
@@ -151,8 +199,35 @@ testCases.large = {
   }
 };
 
-testCases.dim = {
-  description: 'dim',
+testCases.largeLinks = {
+  description: 'large links',
+  component: MbxUnderlineTabs,
+  props: {
+    items: [
+      {
+        id: 'A',
+        label: 'Hash',
+        href: '#'
+      },
+      {
+        id: 'B',
+        label: 'Browns',
+        href: '#'
+      },
+      {
+        id: 'C',
+        label: 'Breakfast',
+        href: '#'
+      }
+    ],
+    active: 'A',
+    onChange: safeSpy(),
+    size: 'large'
+  }
+};
+
+testCases.customized = {
+  description: 'customized',
   component: MbxUnderlineTabs,
   props: {
     items: [
@@ -172,8 +247,10 @@ testCases.dim = {
     active: 'A',
     onChange: safeSpy(),
     size: 'small',
-    activeColor: 'gray-dark',
-    inactiveColor: 'gray'
+    activeColor: 'pink',
+    inactiveColor: 'purple',
+    hoverColor: 'pink',
+    bold: false
   }
 };
 

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs.test.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs.test.js
@@ -1,0 +1,131 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { mount } from 'enzyme';
+import { testCases } from './mbx-underline-tabs-test-cases';
+
+jest.mock('../../mbx-icon-text', () => () => 'MbxIconText');
+
+// Using Enzyme's mount instead of shallow in order to test MbxUnderlineTabItem
+// at the same time, since its independent existence is an implementation
+// detail that may change.
+
+describe(testCases.defaults.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.defaults;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('clicking an inactive item triggers change with the ID and event', () => {
+    const mockEvent = {};
+    wrapper.find({ 'data-test': 'A' }).prop('onClick')(mockEvent);
+    expect(testCase.props.onChange).toHaveBeenCalledTimes(1);
+    expect(testCase.props.onChange).toHaveBeenCalledWith('A', mockEvent);
+  });
+
+  test('clicking an active item does not trigger change and cancels the event', () => {
+    const mockEvent = {
+      preventDefault: jest.fn()
+    };
+    wrapper.find({ 'data-test': 'B' }).prop('onClick')(mockEvent);
+    expect(testCase.props.onChange).toHaveBeenCalledTimes(0);
+    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe(testCases.overlap.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.overlap;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe(testCases.small.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.small;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe(testCases.large.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.large;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe(testCases.customized.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.customized;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe(testCases.idLabelsAndDisabledItem.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.idLabelsAndDisabledItem;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe(testCases.largeLinksIcons.description, () => {
+  let testCase;
+  let wrapper;
+
+  beforeEach(() => {
+    testCase = testCases.largeLinksIcons;
+    wrapper = mount(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('clicking an inactive link item still triggers the onChange callback', () => {
+    const mockEvent = {};
+    wrapper.find({ 'data-test': 'C' }).prop('onClick')(mockEvent);
+    expect(testCase.props.onChange).toHaveBeenCalledTimes(1);
+    expect(testCase.props.onChange).toHaveBeenCalledWith('C', mockEvent);
+  });
+});

--- a/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs.test.js
+++ b/src/components/mbx-underline-tabs/__tests__/mbx-underline-tabs.test.js
@@ -107,6 +107,15 @@ describe(testCases.idLabelsAndDisabledItem.description, () => {
   test('renders as expected', () => {
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('clicking a disabled item does not trigger change and cancels the event', () => {
+    const mockEvent = {
+      preventDefault: jest.fn()
+    };
+    wrapper.find({ 'data-test': 'bug' }).prop('onClick')(mockEvent);
+    expect(testCase.props.onChange).toHaveBeenCalledTimes(0);
+    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe(testCases.largeLinksIcons.description, () => {

--- a/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-a.js
+++ b/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-a.js
@@ -16,6 +16,11 @@ const items = [
   {
     label: 'Dinner',
     id: 'dr'
+  },
+  {
+    label: 'Link here',
+    id: 'link',
+    href: '#mbx-underline-tabs-a'
   }
 ];
 
@@ -30,7 +35,7 @@ export default class Example extends React.Component {
 
   render() {
     return (
-      <div className="border-b border--gray-light">
+      <div id="mbx-underline-tabs-a" className="border-b border--gray-light">
         <MbxUnderlineTabs
           items={items}
           active={this.state.active}

--- a/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-a.js
+++ b/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-a.js
@@ -1,0 +1,43 @@
+/*
+Standard usage.
+*/
+import React from 'react';
+import MbxUnderlineTabs from '../mbx-underline-tabs';
+
+const items = [
+  {
+    label: 'Breakfast',
+    id: 'bf'
+  },
+  {
+    label: 'Lunch',
+    id: 'ln'
+  },
+  {
+    label: 'Dinner',
+    id: 'dr'
+  }
+];
+
+export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { active: 'bf' };
+    this.changeTab = id => {
+      this.setState({ active: id });
+    };
+  }
+
+  render() {
+    return (
+      <div className="border-b border--gray-light">
+        <MbxUnderlineTabs
+          items={items}
+          active={this.state.active}
+          onChange={this.changeTab}
+          overlapBorder={true}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-b.js
+++ b/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-b.js
@@ -1,0 +1,51 @@
+/*
+Small, unbolded tabs, as in Studio's style editor.
+
+Each item's label is derived from its ID instead of separately provided.
+
+Also, the container's layout classes illustrate one way that you can
+right-align the tabs.
+*/
+import React from 'react';
+import MbxUnderlineTabs from '../mbx-underline-tabs';
+
+const items = [
+  {
+    id: 'colors'
+  },
+  {
+    id: 'sizes'
+  },
+  {
+    id: 'shapes'
+  }
+];
+
+export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { active: 'sizes' };
+    this.changeTab = id => {
+      this.setState({ active: id });
+    };
+  }
+
+  render() {
+    return (
+      <div className="px12 py12 bg-gray-faint">
+        <div className="border-b border--gray-light w300 flex-parent flex-parent--end-main">
+          <div className="flex-child">
+            <MbxUnderlineTabs
+              items={items}
+              active={this.state.active}
+              onChange={this.changeTab}
+              size="small"
+              overlapBorder={true}
+              bold={false}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-c.js
+++ b/src/components/mbx-underline-tabs/examples/mbx-underline-tabs-c.js
@@ -1,0 +1,45 @@
+/*
+Large tabs with custom colors, a disabled item, and a container without a bottom border.
+*/
+import React from 'react';
+import MbxUnderlineTabs from '../mbx-underline-tabs';
+
+const items = [
+  {
+    id: 'Robots'
+  },
+  {
+    id: 'Animals',
+    disabled: true
+  },
+  {
+    id: 'Clouds'
+  },
+  {
+    id: 'Messes'
+  }
+];
+
+export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { active: 'Clouds' };
+    this.changeTab = id => {
+      this.setState({ active: id });
+    };
+  }
+
+  render() {
+    return (
+      <MbxUnderlineTabs
+        items={items}
+        active={this.state.active}
+        onChange={this.changeTab}
+        size="large"
+        activeColor="pink"
+        inactiveColor="purple"
+        hoverColor="purple-dark"
+      />
+    );
+  }
+}

--- a/src/components/mbx-underline-tabs/index.js
+++ b/src/components/mbx-underline-tabs/index.js
@@ -1,0 +1,3 @@
+import main from './mbx-underline-tabs';
+
+export default main;

--- a/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
@@ -15,16 +15,18 @@ class MbxUnderlineTabItem extends React.Component {
     };
   }
 
-  // Each return height is 2px more than the perceived height, to account
-  // for the negative margins on top and bottom.
+  // If we're overlapping a bottom border, each height must be 2px
+  // more than the perceived height to account for the negative
+  // margins on top and bottom.
   getHeight() {
+    const offset = this.props.overlapBorder ? 2 : 0;
     switch (this.props.size) {
       case SIZE_SMALL:
-        return 38;
+        return 36 + offset;
       case SIZE_LARGE:
-        return 50;
+        return 48 + offset;
       default:
-        return 44;
+        return 42 + offset;
     }
   }
 
@@ -42,23 +44,20 @@ class MbxUnderlineTabItem extends React.Component {
   render() {
     const { props } = this;
 
-    const itemClasses = classnames(
-      `mb-neg1 mt-neg1 block align-c color-gray-dark txt-nowrap unselectable relative flex-parent flex-parent--center-cross`,
-      {
-        [`color-${props.inactiveColor} color-${
-          props.activeColor
-        }-on-hover`]: !props.active,
-        [`color-${props.activeColor}`]: props.active,
-        'color-gray-light': props.disabled
-      }
-    );
-
-    const itemStyle = {
-      height: this.getHeight(props.size)
-    };
+    const itemClasses = classnames(`block relative`, {
+      'mb-neg1 mt-neg1': props.overlapBorder,
+      [`color-${props.inactiveColor} color-${
+        props.activeColor
+      }-on-hover`]: !props.active,
+      [`color-${props.activeColor}`]: props.active,
+      'color-gray-light': props.disabled
+    });
 
     const content = (
-      <div>
+      <div
+        className="block relative flex-parent flex-parent--center-cross"
+        style={{ height: this.getHeight(props.size) }}
+      >
         {props.label}
         {this.renderBorder()}
       </div>
@@ -66,12 +65,7 @@ class MbxUnderlineTabItem extends React.Component {
 
     if (props.href) {
       return (
-        <a
-          href={props.href}
-          className={itemClasses}
-          data-test={props.id}
-          style={itemStyle}
-        >
+        <a href={props.href} className={itemClasses} data-test={props.id}>
           {content}
         </a>
       );
@@ -83,7 +77,6 @@ class MbxUnderlineTabItem extends React.Component {
         onClick={this.onButtonClick}
         className={itemClasses}
         data-test={props.id}
-        style={itemStyle}
       >
         {content}
       </button>
@@ -99,15 +92,14 @@ MbxUnderlineTabItem.propTypes = {
   onClick: PropTypes.func,
   href: PropTypes.string,
   disabled: PropTypes.string,
-  inactiveColor: PropTypes.string,
-  activeColor: PropTypes.string
+  inactiveColor: PropTypes.string.isRequired,
+  activeColor: PropTypes.string.isRequired,
+  overlapBorder: PropTypes.bool.isRequired
 };
 
 MbxUnderlineTabItem.defaultProps = {
   size: SIZE_MEDIUM,
-  active: false,
-  inactiveColor: 'gray-dark',
-  activeColor: 'blue'
+  active: false
 };
 
 export default MbxUnderlineTabItem;

--- a/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
@@ -13,6 +13,10 @@ class MbxUnderlineTabItem extends React.PureComponent {
     super(props);
 
     this.handleClick = event => {
+      if (props.disabled || props.active) {
+        event.preventDefault();
+        return;
+      }
       props.onClick(props.id, event);
     };
   }
@@ -48,11 +52,10 @@ class MbxUnderlineTabItem extends React.PureComponent {
 
     const itemClasses = classnames(`block relative`, {
       'mb-neg1 mt-neg1': props.overlapBorder,
-      [`color-${props.inactiveColor} color-${
-        props.hoverColor
-      }-on-hover`]: !props.active,
+      [`color-${props.inactiveColor} color-${props.hoverColor}-on-hover`]:
+        !props.active && !props.disabled,
       [`color-${props.activeColor} cursor-default`]: props.active,
-      'color-gray-light': props.disabled
+      'color-gray-light cursor-default': props.disabled
     });
 
     const label = props.label || capitalize(props.id);
@@ -99,12 +102,13 @@ MbxUnderlineTabItem.propTypes = {
   active: PropTypes.bool,
   onClick: PropTypes.func,
   href: PropTypes.string,
-  disabled: PropTypes.string
+  disabled: PropTypes.bool
 };
 
 MbxUnderlineTabItem.defaultProps = {
   size: SIZE_MEDIUM,
-  active: false
+  active: false,
+  disabled: false
 };
 
 export default MbxUnderlineTabItem;

--- a/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import {
+  SIZE_SMALL,
+  SIZE_MEDIUM,
+  SIZE_LARGE
+} from './mbx-underline-tabs-constants';
+import capitalize from '../utils/capitalize';
 
-const SIZE_SMALL = 'small';
-const SIZE_MEDIUM = 'medium';
-const SIZE_LARGE = 'large';
-
-class MbxUnderlineTabItem extends React.Component {
+class MbxUnderlineTabItem extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    this.onButtonClick = () => {
-      props.onClick(props.id);
+    this.handleClick = event => {
+      props.onClick(props.id, event);
     };
   }
 
@@ -47,37 +49,39 @@ class MbxUnderlineTabItem extends React.Component {
     const itemClasses = classnames(`block relative`, {
       'mb-neg1 mt-neg1': props.overlapBorder,
       [`color-${props.inactiveColor} color-${
-        props.activeColor
+        props.hoverColor
       }-on-hover`]: !props.active,
-      [`color-${props.activeColor}`]: props.active,
+      [`color-${props.activeColor} cursor-default`]: props.active,
       'color-gray-light': props.disabled
     });
 
+    const label = props.label || capitalize(props.id);
     const content = (
       <div
         className="block relative flex-parent flex-parent--center-cross"
         style={{ height: this.getHeight(props.size) }}
       >
-        {props.label}
+        {label}
         {this.renderBorder()}
       </div>
     );
 
+    const universalProps = {
+      onClick: this.handleClick,
+      className: itemClasses,
+      'data-test': props.id
+    };
+
     if (props.href) {
       return (
-        <a href={props.href} className={itemClasses} data-test={props.id}>
+        <a href={props.href} {...universalProps}>
           {content}
         </a>
       );
     }
 
     return (
-      <button
-        type="button"
-        onClick={this.onButtonClick}
-        className={itemClasses}
-        data-test={props.id}
-      >
+      <button type="button" {...universalProps}>
         {content}
       </button>
     );
@@ -85,16 +89,17 @@ class MbxUnderlineTabItem extends React.Component {
 }
 
 MbxUnderlineTabItem.propTypes = {
-  label: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired,
+  inactiveColor: PropTypes.string.isRequired,
+  activeColor: PropTypes.string.isRequired,
+  hoverColor: PropTypes.string.isRequired,
+  overlapBorder: PropTypes.bool.isRequired,
+  label: PropTypes.node,
   size: PropTypes.oneOf([SIZE_SMALL, SIZE_MEDIUM, SIZE_LARGE]),
   active: PropTypes.bool,
   onClick: PropTypes.func,
   href: PropTypes.string,
-  disabled: PropTypes.string,
-  inactiveColor: PropTypes.string.isRequired,
-  activeColor: PropTypes.string.isRequired,
-  overlapBorder: PropTypes.bool.isRequired
+  disabled: PropTypes.string
 };
 
 MbxUnderlineTabItem.defaultProps = {

--- a/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
@@ -11,14 +11,16 @@ import capitalize from '../utils/capitalize';
 class MbxUnderlineTabItem extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
 
-    this.handleClick = event => {
-      if (props.disabled || props.active) {
-        event.preventDefault();
-        return;
-      }
-      props.onClick(props.id, event);
-    };
+  handleClick(event) {
+    const { props } = this;
+    if (props.disabled || props.active) {
+      event.preventDefault();
+      return;
+    }
+    props.onClick(props.id, event);
   }
 
   // If we're overlapping a bottom border, each height must be 2px

--- a/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const SIZE_SMALL = 'small';
+const SIZE_MEDIUM = 'medium';
+const SIZE_LARGE = 'large';
+
+class MbxUnderlineTabItem extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.onButtonClick = () => {
+      props.onClick(props.id);
+    };
+  }
+
+  // Each return height is 2px more than the perceived height, to account
+  // for the negative margins on top and bottom.
+  getHeight() {
+    switch (this.props.size) {
+      case SIZE_SMALL:
+        return 38;
+      case SIZE_LARGE:
+        return 50;
+      default:
+        return 44;
+    }
+  }
+
+  renderBorder() {
+    const { props } = this;
+    if (!props.active) {
+      return null;
+    }
+    const borderClasses = classnames('absolute bottom left right border-b', {
+      'border-b--2': props.size !== SIZE_SMALL
+    });
+    return <div className={borderClasses} />;
+  }
+
+  render() {
+    const { props } = this;
+
+    const itemClasses = classnames(
+      `mb-neg1 mt-neg1 block align-c color-gray-dark txt-nowrap unselectable relative flex-parent flex-parent--center-cross`,
+      {
+        [`color-${props.inactiveColor} color-${
+          props.activeColor
+        }-on-hover`]: !props.active,
+        [`color-${props.activeColor}`]: props.active,
+        'color-gray-light': props.disabled
+      }
+    );
+
+    const itemStyle = {
+      height: this.getHeight(props.size)
+    };
+
+    const content = (
+      <div>
+        {props.label}
+        {this.renderBorder()}
+      </div>
+    );
+
+    if (props.href) {
+      return (
+        <a
+          href={props.href}
+          className={itemClasses}
+          data-test={props.id}
+          style={itemStyle}
+        >
+          {content}
+        </a>
+      );
+    }
+
+    return (
+      <button
+        type="button"
+        onClick={this.onButtonClick}
+        className={itemClasses}
+        data-test={props.id}
+        style={itemStyle}
+      >
+        {content}
+      </button>
+    );
+  }
+}
+
+MbxUnderlineTabItem.propTypes = {
+  label: PropTypes.node.isRequired,
+  id: PropTypes.string.isRequired,
+  size: PropTypes.oneOf([SIZE_SMALL, SIZE_MEDIUM, SIZE_LARGE]),
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
+  href: PropTypes.string,
+  disabled: PropTypes.string,
+  inactiveColor: PropTypes.string,
+  activeColor: PropTypes.string
+};
+
+MbxUnderlineTabItem.defaultProps = {
+  size: SIZE_MEDIUM,
+  active: false,
+  inactiveColor: 'gray-dark',
+  activeColor: 'blue'
+};
+
+export default MbxUnderlineTabItem;

--- a/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tab-item.js
@@ -46,7 +46,7 @@ class MbxUnderlineTabItem extends React.PureComponent {
     const borderClasses = classnames('absolute bottom left right border-b', {
       'border-b--2': props.size !== SIZE_SMALL
     });
-    return <div className={borderClasses} />;
+    return <span className={borderClasses} />;
   }
 
   render() {
@@ -62,13 +62,13 @@ class MbxUnderlineTabItem extends React.PureComponent {
 
     const label = props.label || capitalize(props.id);
     const content = (
-      <div
+      <span
         className="block relative flex-parent flex-parent--center-cross"
         style={{ height: this.getHeight(props.size) }}
       >
-        {label}
+        <span className="flex-child">{label}</span>
         {this.renderBorder()}
-      </div>
+      </span>
     );
 
     const universalProps = {

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs-constants.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs-constants.js
@@ -1,0 +1,3 @@
+export const SIZE_SMALL = 'small';
+export const SIZE_MEDIUM = 'medium';
+export const SIZE_LARGE = 'large';

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import MbxUnderlineTabItem from './mbx-underline-tab-item';
+
+const SIZE_SMALL = 'small';
+const SIZE_MEDIUM = 'medium';
+const SIZE_LARGE = 'large';
+
+class MbxUnderlineTabs extends React.PureComponent {
+  renderItems() {
+    const { props } = this;
+    return props.items.map((item, index) => {
+      const isFirst = index === 0;
+      const layoutClasses = classnames('flex-child', {
+        'ml24 ml36-mxl': !isFirst && props.size === SIZE_MEDIUM,
+        ml12: !isFirst && props.size === SIZE_SMALL,
+        ml24: !isFirst && props.size === SIZE_LARGE
+      });
+      return (
+        <div key={item.id} className={layoutClasses}>
+          <MbxUnderlineTabItem
+            active={props.active === item.id}
+            onClick={props.onChange}
+            size={props.size}
+            inactiveColor={props.inactiveColor}
+            activeColor={props.activeColor}
+            {...item}
+          />
+        </div>
+      );
+    });
+  }
+
+  render() {
+    const { props } = this;
+    const containerClasses = classnames('flex-parent', {
+      'txt-s': props.size === SIZE_MEDIUM,
+      'txt-xs': props.size === SIZE_SMALL
+    });
+    return <div className={containerClasses}>{this.renderItems()}</div>;
+  }
+}
+
+MbxUnderlineTabs.propTypes = {
+  size: PropTypes.oneOf([SIZE_SMALL, SIZE_MEDIUM, SIZE_LARGE]),
+  active: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node.isRequired,
+      id: PropTypes.string,
+      onClick: PropTypes.func,
+      href: PropTypes.string,
+      disabled: PropTypes.string
+    })
+  ).isRequired,
+  onChange: PropTypes.func,
+  inactiveColor: PropTypes.string,
+  activeColor: PropTypes.string
+};
+
+MbxUnderlineTabs.defaultProps = {
+  size: SIZE_MEDIUM
+};
+
+export default MbxUnderlineTabs;

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -2,69 +2,113 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import MbxUnderlineTabItem from './mbx-underline-tab-item';
+import {
+  SIZE_SMALL,
+  SIZE_MEDIUM,
+  SIZE_LARGE
+} from './mbx-underline-tabs-constants';
 
-const SIZE_SMALL = 'small';
-const SIZE_MEDIUM = 'medium';
-const SIZE_LARGE = 'large';
-
-class MbxUnderlineTabs extends React.PureComponent {
-  renderItems() {
+/**
+ * For navigation between pages or sections.
+ *
+ * Items can be `<a>`s or `<button>`s, depending on whether they have
+ * `href` props or not.
+ */
+class MbxUnderlineTabs extends React.Component {
+  render() {
     const { props } = this;
-    return props.items.map((item, index) => {
-      const isFirst = index === 0;
+
+    const small = props.size === SIZE_SMALL;
+    const medium = props.size === SIZE_MEDIUM;
+    const large = props.size === SIZE_LARGE;
+
+    const containerClasses = classnames('flex-parent txt-nowrap unselectable', {
+      'txt-bold': props.bold,
+      'txt-s': medium,
+      'txt-xs': small
+    });
+
+    const itemEls = props.items.map((item, index) => {
+      const first = index === 0;
       const layoutClasses = classnames('flex-child', {
-        'ml24 ml36-mxl': !isFirst && props.size === SIZE_MEDIUM,
-        ml12: !isFirst && props.size === SIZE_SMALL,
-        ml24: !isFirst && props.size === SIZE_LARGE
+        ml12: !first && small,
+        'ml24 ml36-mxl': !first && medium,
+        ml24: !first && large
       });
       return (
-        <div key={item.id} className={layoutClasses}>
+        <li key={item.id} className={layoutClasses}>
           <MbxUnderlineTabItem
             active={props.active === item.id}
             onClick={props.onChange}
             size={props.size}
             inactiveColor={props.inactiveColor}
             activeColor={props.activeColor}
+            hoverColor={props.hoverColor}
             overlapBorder={props.overlapBorder}
             {...item}
           />
-        </div>
+        </li>
       );
     });
-  }
 
-  render() {
-    const { props } = this;
-    const containerClasses = classnames('flex-parent txt-nowrap unselectable', {
-      'txt-s': props.size === SIZE_MEDIUM,
-      'txt-xs': props.size === SIZE_SMALL
-    });
-    return <div className={containerClasses}>{this.renderItems()}</div>;
+    return <ul className={containerClasses}>{itemEls}</ul>;
   }
 }
 
 MbxUnderlineTabs.propTypes = {
-  size: PropTypes.oneOf([SIZE_SMALL, SIZE_MEDIUM, SIZE_LARGE]),
-  active: PropTypes.string.isRequired,
+  /**
+   * Each item is an object with the following properties:
+   * - `id` (required): A string ID.
+   * - `label`: Text or React element. If `label` is not provided, `id` will
+   *   be used, with its first letter capitalized.
+   * - `href`: A URL. If `href` is provided, the items will be `<a>`s.
+   *   If not, the items will be `<button>`s.
+   * -`disabled`: Boolean.
+   */
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.node.isRequired,
       id: PropTypes.string.isRequired,
+      label: PropTypes.node,
       href: PropTypes.string,
       disabled: PropTypes.string
     })
   ).isRequired,
+  /**
+   * The ID of the active item. Value must correspond with an `id` property in the `items` array.
+   */
+  active: PropTypes.string.isRequired,
+  /**
+   * A callback that will be invoked when an item is clicked.
+   * It will receive the ID of the clicked item and the click `event` itself as arguments.
+   */
   onChange: PropTypes.func,
+  /**
+   * Three sizes: "small", "medium", or "large"
+   */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /**
+   * If `true`, the element will extend down one pixel so the underline beneath
+   * the active item overlaps the bottom border of a container.
+   * **You must provide your own bottom border.**
+   */
+  overlapBorder: PropTypes.bool,
+  /** The Assembly color of inactive items. */
   inactiveColor: PropTypes.string,
+  /** The Assembly color of active items. */
   activeColor: PropTypes.string,
-  overlapBorder: PropTypes.bool
+  /** The Assembly color of hovered inactive items. */
+  hoverColor: PropTypes.string,
+  /** Whether or not the text is bold. */
+  bold: PropTypes.bool
 };
 
 MbxUnderlineTabs.defaultProps = {
-  size: SIZE_MEDIUM,
-  inactiveColor: 'gray-dark',
-  activeColor: 'blue',
-  overlapBorder: true
+  size: 'medium',
+  inactiveColor: 'gray',
+  activeColor: 'gray-dark',
+  hoverColor: 'blue',
+  overlapBorder: false,
+  bold: true
 };
 
 export default MbxUnderlineTabs;

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -60,7 +60,8 @@ MbxUnderlineTabs.propTypes = {
    * Each item is an object with the following properties:
    * - `id` (required): A string ID.
    * - `label`: Text or React element. If `label` is not provided, `id` will
-   *   be used, with its first letter capitalized.
+   *   be used, with its first letter capitalized. (You should provide your
+   *   own `label` unless your `id`s are single words.)
    * - `href`: A URL. If `href` is provided, the items will be `<a>`s.
    *   If not, the items will be `<button>`s.
    * -`disabled`: Boolean.
@@ -70,7 +71,7 @@ MbxUnderlineTabs.propTypes = {
       id: PropTypes.string.isRequired,
       label: PropTypes.node,
       href: PropTypes.string,
-      disabled: PropTypes.string
+      disabled: PropTypes.bool
     })
   ).isRequired,
   /**

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -11,8 +11,8 @@ import {
 /**
  * For navigation between pages or sections.
  *
- * Items will be `<button>`s or `<a>`s, depending on whether they have
- * `href` props or not.
+ * Items will be `<button>`s or `<a>`s, depending on whether they
+ * have `href` props or not.
  */
 class MbxUnderlineTabs extends React.Component {
   render() {

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -25,6 +25,7 @@ class MbxUnderlineTabs extends React.PureComponent {
             size={props.size}
             inactiveColor={props.inactiveColor}
             activeColor={props.activeColor}
+            overlapBorder={props.overlapBorder}
             {...item}
           />
         </div>
@@ -34,7 +35,7 @@ class MbxUnderlineTabs extends React.PureComponent {
 
   render() {
     const { props } = this;
-    const containerClasses = classnames('flex-parent', {
+    const containerClasses = classnames('flex-parent txt-nowrap unselectable', {
       'txt-s': props.size === SIZE_MEDIUM,
       'txt-xs': props.size === SIZE_SMALL
     });
@@ -48,19 +49,22 @@ MbxUnderlineTabs.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.node.isRequired,
-      id: PropTypes.string,
-      onClick: PropTypes.func,
+      id: PropTypes.string.isRequired,
       href: PropTypes.string,
       disabled: PropTypes.string
     })
   ).isRequired,
   onChange: PropTypes.func,
   inactiveColor: PropTypes.string,
-  activeColor: PropTypes.string
+  activeColor: PropTypes.string,
+  overlapBorder: PropTypes.bool
 };
 
 MbxUnderlineTabs.defaultProps = {
-  size: SIZE_MEDIUM
+  size: SIZE_MEDIUM,
+  inactiveColor: 'gray-dark',
+  activeColor: 'blue',
+  overlapBorder: true
 };
 
 export default MbxUnderlineTabs;

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -2,11 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import MbxUnderlineTabItem from './mbx-underline-tab-item';
-import {
-  SIZE_SMALL,
-  SIZE_MEDIUM,
-  SIZE_LARGE
-} from './mbx-underline-tabs-constants';
+import { SIZE_SMALL, SIZE_MEDIUM } from './mbx-underline-tabs-constants';
 
 /**
  * For navigation between pages or sections.
@@ -20,7 +16,6 @@ class MbxUnderlineTabs extends React.Component {
 
     const small = props.size === SIZE_SMALL;
     const medium = props.size === SIZE_MEDIUM;
-    const large = props.size === SIZE_LARGE;
 
     const containerClasses = classnames('flex-parent txt-nowrap unselectable', {
       'txt-bold': props.bold,
@@ -32,8 +27,7 @@ class MbxUnderlineTabs extends React.Component {
       const first = index === 0;
       const layoutClasses = classnames('flex-child', {
         ml12: !first && small,
-        'ml24 ml36-mxl': !first && medium,
-        ml24: !first && large
+        'ml24 ml36-mxl': !first && !small
       });
       return (
         <li key={item.id} className={layoutClasses}>
@@ -64,7 +58,7 @@ MbxUnderlineTabs.propTypes = {
    *   own `label` unless your `id`s are single words.)
    * - `href`: A URL. If `href` is provided, the items will be `<a>`s.
    *   If not, the items will be `<button>`s.
-   * -`disabled`: Boolean.
+   * - `disabled`: Boolean.
    */
   items: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/mbx-underline-tabs/mbx-underline-tabs.js
+++ b/src/components/mbx-underline-tabs/mbx-underline-tabs.js
@@ -11,7 +11,7 @@ import {
 /**
  * For navigation between pages or sections.
  *
- * Items can be `<a>`s or `<button>`s, depending on whether they have
+ * Items will be `<button>`s or `<a>`s, depending on whether they have
  * `href` props or not.
  */
 class MbxUnderlineTabs extends React.Component {
@@ -75,7 +75,8 @@ MbxUnderlineTabs.propTypes = {
     })
   ).isRequired,
   /**
-   * The ID of the active item. Value must correspond with an `id` property in the `items` array.
+   * The ID of the active item. Value must correspond with an `id` property
+   * in the `items` array.
    */
   active: PropTypes.string.isRequired,
   /**
@@ -84,13 +85,14 @@ MbxUnderlineTabs.propTypes = {
    */
   onChange: PropTypes.func,
   /**
-   * Three sizes: "small", "medium", or "large"
+   * Three sizes: "small", "medium", or "large".
    */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /**
    * If `true`, the element will extend down one pixel so the underline beneath
    * the active item overlaps the bottom border of a container.
-   * **You must provide your own bottom border.**
+   * **You must provide your own bottom border,** by setting it on a container
+   * element.
    */
   overlapBorder: PropTypes.bool,
   /** The Assembly color of inactive items. */

--- a/src/components/utils/capitalize.js
+++ b/src/components/utils/capitalize.js
@@ -1,0 +1,3 @@
+export default function capitalize(x) {
+  return x[0].toUpperCase() + x.slice(1);
+}

--- a/src/docs/components/component-example.js
+++ b/src/docs/components/component-example.js
@@ -26,7 +26,7 @@ export default class ComponentExample extends React.Component {
     return (
       <div>
         <div className="flex-parent flex-parent--end-cross">
-          <div className="flex-child flex-child--grow pb6">
+          <div className="flex-child flex-child--grow pb6 prose">
             {props.description}
           </div>
           <div className="flex-child flex-child--no-shrink w120">

--- a/src/docs/components/component-section.js
+++ b/src/docs/components/component-section.js
@@ -33,7 +33,7 @@ export default class ComponentSection extends React.Component {
 
     const exampleEls = data.examples.map((example, i) => {
       return (
-        <div key={i} className="my12">
+        <div key={i} className="my24">
           <ComponentExample {...example} />
         </div>
       );
@@ -99,7 +99,7 @@ function PropRow(props) {
 
   return (
     <tr>
-      <td className="txt-mono txt-bold">
+      <td className="txt-mono txt-bold txt-nowrap">
         {props.name} {required}
       </td>
       <td className="txt-mono mx12">{props.type.name}</td>


### PR DESCRIPTION
Closes #9.

Here's what we have so far:

<img width="663" alt="screen shot 2018-07-31 at 9 14 04 am" src="https://user-images.githubusercontent.com/628431/43472451-54aa2498-94a2-11e8-8163-e1f6b286d5fa.png">

![localhost_9966_mbxunderlinetabs](https://user-images.githubusercontent.com/628431/43472443-50846d2e-94a2-11e8-8ca3-86c1d788dccb.png)
