### PR TITLE
Proof-of-concept for theme props approach

### DIFF
--- a/src/components/button/__tests__/__snapshots__/button.test.js.snap
+++ b/src/components/button/__tests__/__snapshots__/button.test.js.snap
@@ -50,7 +50,7 @@ exports[`Discouraging renders as expected 1`] = `
 </button>
 `;
 
-exports[`Div styled like a medium destructive button with some extended props and transformed classes renders as expected 1`] = `
+exports[`Div styled like a medium destructive button with some extended props and custom classes renders as expected 1`] = `
 <div
   className="btn btn--red round-full py6 px24 txt-s shadow-darken75 unselectable cursor-pointer"
   data-test="foo"

--- a/src/components/button/__tests__/button-test-cases.js
+++ b/src/components/button/__tests__/button-test-cases.js
@@ -88,16 +88,14 @@ testCases.fullWidthPurple = {
 
 testCases.weird = {
   description:
-    'Div styled like a medium destructive button with some extended props and transformed classes',
+    'Div styled like a medium destructive button with some extended props and custom classes',
   component: Button,
   props: {
     children: 'Save',
     size: 'medium',
     variant: 'destructive',
     onClick: safeSpy(),
-    transformClasses: classes => {
-      return classes + ' shadow-darken75 unselectable cursor-pointer';
-    },
+    theme: 'shadow-darken75 unselectable cursor-pointer',
     component: 'div',
     role: 'button',
     'data-test': 'foo'

--- a/src/components/button/__tests__/button.test.js
+++ b/src/components/button/__tests__/button.test.js
@@ -1,7 +1,5 @@
 import React from 'react';
-
 import { shallow } from 'enzyme';
-
 import { testCases } from './button-test-cases';
 
 describe(testCases.primary.description, () => {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import xtend from 'xtend';
 import omit from '../utils/omit';
+import applyTheme from '../utils/apply-theme';
 
 // This list must be kept in sync with the propTypes.
 // It's used to identify additional props that should be passed directly
@@ -17,7 +18,7 @@ const propNames = [
   'onClick',
   'outline',
   'size',
-  'transformClasses',
+  'theme',
   'variant',
   'width'
 ];
@@ -49,7 +50,7 @@ class Button extends React.Component {
     const widthMedium = props.width === 'medium';
     const widthLarge = props.width === 'large';
 
-    const classes = classnames('btn', {
+    const buttonClasses = classnames('btn', {
       [`btn--${props.color}`]: props.color,
       'btn--stroke': props.outline,
       'btn--stroke--2': props.outline && !sizeSmall,
@@ -70,7 +71,7 @@ class Button extends React.Component {
 
     const universalProps = xtend(
       {
-        className: props.transformClasses(classes),
+        className: applyTheme(buttonClasses, props.theme),
         onClick: props.onClick,
         children: props.children
       },
@@ -96,6 +97,7 @@ const defaults = {
   size: 'large',
   width: 'medium'
 };
+
 function applyVariant(props) {
   switch (props.variant) {
     case 'primary':
@@ -232,11 +234,10 @@ Button.propTypes = {
    */
   block: PropTypes.bool,
   /**
-   * A callback for transforming the class list. Receives the standard class
-   * list (based on your other props) as an argument; it must return
-   * the transformed class list.
+   * Modify the button element's class list.
+   * See the [`theme*` props documentation](#themeprops).
    */
-  transformClasses: PropTypes.func,
+  theme: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /**
    * An alternate component to render in the style of a button. If the value is
    * a string, it must refer to a DOM element, like `"div"`. Otherwise, it
@@ -247,8 +248,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   variant: 'primary',
-  block: false,
-  transformClasses: x => x
+  block: false
 };
 
 export default Button;

--- a/src/components/utils/apply-theme.js
+++ b/src/components/utils/apply-theme.js
@@ -1,0 +1,18 @@
+/**
+ * Apply a "theme*" prop to a class list.
+ *
+ * @param {string} original
+ * @param {string | string => string} [theme]
+ * @return {string}
+ */
+export default function applyTheme(original, theme) {
+  if (!theme) {
+    return original;
+  }
+  if (typeof theme === 'string') {
+    return original + ' ' + theme;
+  }
+  if (typeof theme === 'function') {
+    return theme(original);
+  }
+}

--- a/src/docs/app.js
+++ b/src/docs/app.js
@@ -2,6 +2,7 @@ import React from 'react';
 import components from './data/components'; // eslint-disable-line
 import ComponentSection from './components/component-section';
 import Sidebar from './components/sidebar';
+import ThemeProps from './components/theme-props';
 
 export default class App extends React.Component {
   render() {
@@ -21,7 +22,12 @@ export default class App extends React.Component {
         <div className="fixed top left bottom w300 py24 px24 scroll-styled scroll-auto">
           <Sidebar />
         </div>
-        <div className="ml300 px24">{componentEls}</div>
+        <div className="ml300 px24">
+          {componentEls}
+          <div className="my60">
+            <ThemeProps />
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/docs/components/component-section.js
+++ b/src/docs/components/component-section.js
@@ -6,7 +6,11 @@ export default class ComponentSection extends React.Component {
     const { data } = this.props;
     if (!data) return null;
 
-    const propRows = sortedProps(data.props).map(propData => {
+    const allProps = sortedProps(data.props);
+    const nonThemeProps = allProps.filter(p => !isThemeProp(p));
+    const themeProps = allProps.filter(isThemeProp);
+
+    const propRows = nonThemeProps.map(propData => {
       return <PropRow key={propData.name} {...propData} />;
     });
 
@@ -23,6 +27,7 @@ export default class ComponentSection extends React.Component {
           </thead>
           <tbody>{propRows}</tbody>
         </table>
+        <ThemeProps themePropsData={themeProps} />
       </div>
     );
   }
@@ -90,6 +95,10 @@ function sortedProps(propsData) {
     });
 }
 
+function isThemeProp(prop) {
+  return /^theme/.test(prop.name);
+}
+
 function PropRow(props) {
   const required = !props.required ? null : (
     <span className="txt-xs txt-mono ml6 bg-purple-faint color-purple px6 py3 round">
@@ -97,10 +106,16 @@ function PropRow(props) {
     </span>
   );
 
+  const renderedName = isThemeProp(props.name) ? (
+    <span className="color-gray">{props.name}</span>
+  ) : (
+    props.name
+  );
+
   return (
     <tr>
       <td className="txt-mono txt-bold txt-nowrap">
-        {props.name} {required}
+        {renderedName} {required}
       </td>
       <td className="txt-mono mx12">{props.type.name}</td>
       <td>
@@ -137,4 +152,30 @@ function DefaultValueDisplay(props) {
     );
   }
   return <div className="inline-block txt-code">{props.value}</div>;
+}
+
+function ThemeProps(props) {
+  if (props.themePropsData.length === 0) {
+    return null;
+  }
+
+  const renderedThemeProps = props.themePropsData.map(propData => {
+    return (
+      <span className="inline-block mr6 mb6 txt-code">{propData.name}</span>
+    );
+  });
+
+  return (
+    <div className="mt24">
+      <div className="mb6">
+        <span className="txt-bold mr6">Theme props:</span>
+        {renderedThemeProps}
+      </div>
+      <div>
+        <a href="#themeprops" className="link">
+          Learn more about theme props
+        </a>
+      </div>
+    </div>
+  );
 }

--- a/src/docs/components/theme-props.js
+++ b/src/docs/components/theme-props.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export default class ThemeProps extends React.Component {
+  render() {
+    return (
+      <div>
+        <h2 id="themeprops" className="txt-fancy txt-h3 mb24">
+          <code>theme*</code> props
+        </h2>
+        <div className="prose">
+          <p>
+            Advanced users may want to customize the class lists of elements
+            rendered by a component. To allow for this, many components expose{' '}
+            <code>theme*</code> props, such as <code>themeButton</code>,{' '}
+            <code>themeContainer</code>, or just <code>theme</code>.
+          </p>
+          <p>
+            The value of a <code>theme*</code> prop can be a string or a
+            function. If it's a string, that string will be appended to the
+            element's standard class list. If it's a function, the function will
+            be passed the element's standard class list and whatever the
+            function returns will be passed to the element.
+          </p>
+          <p>
+            <strong>String example:</strong> To append <code>mr6</code> to the
+            class list of a component's container element, you could provide{' '}
+            <code>themeContainer="mr6"</code>.
+          </p>
+          <p>
+            <strong>Function example:</strong> To remove <code>txt-bold</code>{' '}
+            from and add <code>txt-em</code> to the class list of a component's
+            button element, you could provide the following:
+          </p>
+          <pre>
+            <code>
+              themeContainer={'{'}original => original.replace('txt-bold',
+              'txt-em'){'}'}
+            </code>
+          </pre>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/mapbox/mr-ui/issues/26

The first commit on this PR does a few things:

- Modify the Button component to have a `theme` prop that fits the convention proposed in #26: string values are appended, function values replace.
- Create an `applyTheme` function that we can use to apply the same convention all over the place.
- Modify the documentation to de-emphasize `theme*` props, since they are for advanced users, and explain them all in one place.

If we like this approach, I guess the next step would be to modify all the existing components to follow the new convention. To be clear, it would a breaking change: usage of `theme*` strings right now would have to adjust to accommodate the change. The intended benefit of the change is to help the most common use case and the less advanced users. If you disagree and think we should just stick with the current `theme*` behavior — where `theme*` props take a string and that string replaces the class list wholesale — please let me know! cc @tristen @mapbox/studio @frontend

Here are some shots of what the docs look like:

<img width="558" alt="screen shot 2018-08-03 at 5 15 21 pm" src="https://user-images.githubusercontent.com/628431/43670501-4ce49c1a-9741-11e8-8a8d-d8ac02845df4.png">
<img width="335" alt="screen shot 2018-08-03 at 5 15 28 pm" src="https://user-images.githubusercontent.com/628431/43670502-4cf8e602-9741-11e8-88b9-1384f54a3f15.png">
<img width="759" alt="screen shot 2018-08-03 at 5 15 39 pm" src="https://user-images.githubusercontent.com/628431/43670503-4d0af18a-9741-11e8-839f-c66432aff985.png">
<img width="721" alt="screen shot 2018-08-03 at 5 15 46 pm" src="https://user-images.githubusercontent.com/628431/43670504-4d1e23f4-9741-11e8-8bc4-26fa3e8d64f3.png">
