### PR TITLE
Add maxWidth to Tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - [fix] Works in modals.
 - **Tooltip**
   - 🚨 [breaking change] Remove `backgroundColor` and `themeTooltip` props.
-  - [feature] Add `coloring` and `padded` props.
+  - [feature] Add `coloring`, `padded`, and `maxWidth` props.
   - [feature] Children of Tooltip no longer need to be functions! If you provide a standard DOM element (e.g. `<button>`, `<div>`, `<span>`) or a Button component, things will just work. You can still use a function if your trigger is a custom component.
 
 ## 0.2.1

--- a/src/components/icon-button/__tests__/__snapshots__/icon-button.test.js.snap
+++ b/src/components/icon-button/__tests__/__snapshots__/icon-button.test.js.snap
@@ -13,7 +13,8 @@ exports[`IconButton all props used, JSX content renders 1`] = `
     </span>
   }
   disabled={false}
-  display="inline-flex"
+  display="inline-block"
+  maxWidth="medium"
   padded={true}
   placement="right"
   respondsToClick={true}
@@ -45,6 +46,7 @@ exports[`IconButton basic renders 1`] = `
   content="close"
   disabled={false}
   display="inline-block"
+  maxWidth="medium"
   padded={true}
   placement="top"
   respondsToClick={false}

--- a/src/components/icon-button/__tests__/icon-button-test-cases.js
+++ b/src/components/icon-button/__tests__/icon-button-test-cases.js
@@ -30,7 +30,7 @@ testCases.allPropsJsxContent = {
       backgroundColor: 'yellow',
       respondsToClick: true,
       themeTooltip: 'color-gray round px12 py12 shadow-darken25',
-      display: 'inline-flex',
+      display: 'inline-block',
       testId: 'tooltip-test-id'
     },
     themeButton: 'px12 py12 bg-gray',

--- a/src/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/tooltip.test.js.snap
@@ -19,7 +19,7 @@ exports[`Tooltip DOM element child renders as expected 1`] = `
 <PopoverTrigger
   content={
     <div
-      className="px12 py6 txt-s"
+      className="px12 py6 txt-s wmax240"
     >
       DOM element child
     </div>

--- a/src/components/tooltip/__tests__/tooltip-test-cases.js
+++ b/src/components/tooltip/__tests__/tooltip-test-cases.js
@@ -10,7 +10,7 @@ function getTooltipChildren() {
 }
 
 function getTooltipContent() {
-  return <div className="w240 h72">test tooltip</div>;
+  return <div className="h72">test tooltip</div>;
 }
 
 function getTooltipList(options = {}) {

--- a/src/components/tooltip/examples/tooltip-b.js
+++ b/src/components/tooltip/examples/tooltip-b.js
@@ -1,7 +1,7 @@
 /*
 A dark tooltip with custom placement, which uses a function child
 to render a custom component as  the trigger and a function for its
-`content` prop.
+`content` prop. Also limits itself to a small width.
 */
 import React from 'react';
 import Tooltip from '../tooltip';
@@ -22,6 +22,7 @@ export default class Example extends React.Component {
         placement="bottom"
         alignment="left"
         coloring="dark"
+        maxWidth="small"
       >
         {triggerProps => <CustomTrigger spanProps={triggerProps} />}
       </Tooltip>

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -79,7 +79,9 @@ export default class Tooltip extends React.Component {
     const bodyClasses = classnames({
       'px12 py6': props.padded,
       'txt-s': props.textSize === 's',
-      'txt-xs': props.textSize === 'xs'
+      'txt-xs': props.textSize === 'xs',
+      wmax120: props.maxWidth === 'small',
+      wmax240: props.maxWidth === 'medium'
     });
 
     const content = <div className={bodyClasses}>{this.getContent()}</div>;
@@ -151,6 +153,10 @@ Tooltip.propTypes = {
    */
   textSize: PropTypes.oneOf(['xs', 's', 'none']),
   /**
+   * `'small'`, `'medium'`, or `'none'` (no `wmax*` class).
+   */
+  maxWidth: PropTypes.oneOf(['small', 'medium', 'none']),
+  /**
    * Set to `false` to remove the default padding on the popover body
    * (and, hopefully, apply your own).
    */
@@ -177,5 +183,6 @@ Tooltip.defaultProps = {
   respondsToClick: false,
   padded: true,
   display: 'inline-block',
-  textSize: 's'
+  textSize: 's',
+  maxWidth: 'medium'
 };


### PR DESCRIPTION
Takes care of one bit I forgot from #14 when I put together #32: add a default (but configurable) max-width to the Tooltip.

@jseppi for review, please.