### PR TITLE
Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ UI components for Mapbox projects.
 npm install @mapbox/mr-ui
 ```
 
-On Mapbox projects, pair these components with version 0.26.0 of Mapbox's custom [Assembly](https://www.mapbox.com/assembly/) build. (This is not in `peerDependencies` because you might use `<link>` and `<script>` tags instead of the npm package.)
+On Mapbox projects, pair these components with version 0.26.0+ of Mapbox's custom [Assembly](https://www.mapbox.com/assembly/) build. (This is not in `peerDependencies` because you might use `<link>` and `<script>` tags instead of the npm package.)
 
 The public Assembly build should work fine, with maybe one or two hiccups.
 

--- a/batfish-docs.config.js
+++ b/batfish-docs.config.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = () => {
   return {
     siteBasePath: 'mr-ui',
-    stylesheets: [require.resolve('prismjs/themes/prism.css')],
+    stylesheets: [path.join(__dirname, './src/docs/prism-theme.css')],
     spa: true,
     staticHtmlInlineDeferCss: false,
     pagesDirectory: path.join(__dirname, './src/docs/pages')

--- a/scripts/build-docs-data.js
+++ b/scripts/build-docs-data.js
@@ -24,12 +24,15 @@ const excludeSourceDirs = new Set(['page-loading-indicator', 'utils']);
 
 function processExampleFile(filename) {
   return pify(fs.readFile)(filename, 'utf8').then(code => {
+    // Assumes there is only one block comment, and it is the description.
     const descriptionMatch = /\/\*([\s\S]+?)\*\//.exec(code);
     if (!descriptionMatch) {
       throw new Error(`No description found for example ${filename}`);
     }
     code = code
-      .replace(`from '../src/`, `from '@mapbox/mr-ui/`)
+      // Replace imported component paths with npm package paths.
+      .replace(/from '\.\.\/(\.\.\/)?/g, `from '@mapbox/mr-ui/`)
+      // Remove block comments (especially the description).
       .replace(/\/\*[\s\S]*?\*\/[\s]*/, '')
       .trim();
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -11,7 +11,7 @@ import xtend from 'xtend';
  * render a different element altogether.)
  *
  * If you'd like to put an icon before or after the text of your button,
- * use [IconText](#mbxicontext) for the content.
+ * use [IconText](#icontext) for the content.
  */
 class Button extends React.Component {
   render() {
@@ -134,7 +134,7 @@ Button.propTypes = {
   /**
    * The button's content. A string is recommended, but you can put an element
    * in here if you think that's right. If you do, it should be inline-level,
-   * using `<span>`s instead of `<div>`s. ([IconText](#mbxicontext) is
+   * using `<span>`s instead of `<div>`s. ([IconText](#icontext) is
    * inline-level.)
    */
   children: PropTypes.node.isRequired,

--- a/src/components/button/examples/button-b.js
+++ b/src/components/button/examples/button-b.js
@@ -1,5 +1,5 @@
 /*
-A slightly wider, outlined button with an alternate color, using [IconText](#mbxicontext) to prefix the text with an icon.
+A slightly wider, outlined button with an alternate color, using [IconText](#icontext) to prefix the text with an icon.
 */
 import React from 'react';
 import Button from '../button';

--- a/src/docs/components/component-example.js
+++ b/src/docs/components/component-example.js
@@ -15,7 +15,7 @@ export default class ComponentExample extends React.Component {
       return null;
     }
     return (
-      <pre className="my0 round-tl pre language-jsx">
+      <pre className="my0 round-tl pre language-jsx unround-tr unround-b">
         <code dangerouslySetInnerHTML={{ __html: this.props.code }} />
       </pre>
     );

--- a/src/docs/components/component-section.js
+++ b/src/docs/components/component-section.js
@@ -33,7 +33,7 @@ export default class ComponentSection extends React.Component {
 
     const exampleEls = data.examples.map((example, i) => {
       return (
-        <div key={i} className="my24">
+        <div key={i} className="mb12">
           <ComponentExample {...example} />
         </div>
       );
@@ -41,7 +41,7 @@ export default class ComponentSection extends React.Component {
 
     return (
       <div className="mt24 mb12">
-        <h3 className="txt-h4 txt-bold pb6">Examples</h3>
+        <h3 className="txt-h4 txt-bold mb12">Examples</h3>
         {exampleEls}
       </div>
     );

--- a/src/docs/pages/index.js
+++ b/src/docs/pages/index.js
@@ -9,14 +9,15 @@ export default class Page extends React.Component {
         <Helmet>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width,initial-scale=1" />
+          <meta name="robots" content="noindex" />
           <title>Mr. UI</title>
           <link
-            href="https://api.mapbox.com/mapbox-assembly/mbx/v0.26.0/assembly.min.css"
+            href="https://api.mapbox.com/mapbox-assembly/mbx/v0.27.0/assembly.min.css"
             rel="stylesheet"
           />
           <script
             async
-            src="https://api.mapbox.com/mapbox-assembly/mbx/v0.26.0/assembly.js"
+            src="https://api.mapbox.com/mapbox-assembly/mbx/v0.27.0/assembly.js"
           />
         </Helmet>
         <App />

--- a/src/docs/prism-theme.css
+++ b/src/docs/prism-theme.css
@@ -1,0 +1,109 @@
+code[class*="language-"],
+pre[class*="language-"] {
+    color: #273d56;
+    direction: ltr;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+
+    -moz-tab-size: 2;
+    -o-tab-size: 2;
+    tab-size: 2;
+
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+    background: #aab7ef;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+    background: #aab7ef;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+    /* padding: 1em; */
+    margin: .5em 0;
+    overflow: auto;
+    border: 1px solid #dddddd;
+    /* background-color: white; */
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+    padding: .2em;
+    padding-top: 1px; padding-bottom: 1px;
+    background: #f8f8f8;
+    border: 1px solid #dddddd;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+    color: #999988; font-style: italic;
+}
+
+.token.namespace {
+    opacity: .7;
+}
+
+.token.tag .token.tag,
+.token.selector {
+    color: #7753eb;
+}
+
+.token.string,
+.token.attr-value {
+    color: #ee4e8b;
+}
+.token.punctuation,
+.token.operator {
+    color: #607d9c; /* no highlight */
+}
+
+.token.entity,
+.token.url,
+.token.symbol,
+.token.number,
+.token.boolean,
+.token.variable,
+.token.constant,
+.token.property,
+.token.regex,
+.token.inserted {
+    color: #33c377;
+}
+
+.token.atrule,
+.token.keyword,
+.language-autohotkey .token.selector {
+    color: #314ccd;
+}
+
+.token.function,
+.token.deleted,
+.language-autohotkey .token.tag {
+    color: #ba3b3f;
+}
+
+.token.important,
+.token.function,
+.token.bold {
+    font-weight: bold;
+}
+
+.token.italic {
+    font-style: italic;
+}


### PR DESCRIPTION
- Made a nicer syntax highlighting scheme.
- Fixed path names to components in examples.
- Fixed some links and small details in docs.
- Updated the Assembly version.
- Added a `<meta name="robots" content="noindex" />` tag, since once we publish this page on gh-pages we don't really want this page getting indexed — at least not yet, since many examples in the docs are still very sloppy.

@danswick for review, please. I'm thinking that after this merges we could cut a release with all the pending changes.