### PR TITLE
A few fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   - [feature] Add `CopyButton.copyIsSupported()` static function.
   - [feature] Improve appearance of copy instructions popover.
   - [fix] Works in modals.
+- **Copiable**
+  - 🚨 [breaking change] Remove `themeWrapper`, `themeCopyButtonContainer`, `themeCopyButton`, `themeText`, and `themeTooltip` props.
+  - [feature] Add `truncate` prop.
 - **Tooltip**
   - 🚨 [breaking change] Remove `backgroundColor` and `themeTooltip` props.
   - 🚨 [breaking change] Replace `display` prop with `block`.

--- a/scripts/build-docs-data.js
+++ b/scripts/build-docs-data.js
@@ -49,7 +49,7 @@ function processExampleFile(filename) {
 function getExamples(componentDirectory) {
   const examplesDirectory = path.join(componentDirectory, 'examples');
   return globby(path.join(examplesDirectory, '*.js')).then(filenames => {
-    return Promise.all(filenames.map(processExampleFile));
+    return Promise.all(filenames.sort().map(processExampleFile));
   });
 }
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -231,9 +231,7 @@ Button.propTypes = {
    * the button, assign an ID for testing, add an ARIA attribute, toss in some
    * custom style properties, etc.
    */
-  passthroughProps: PropTypes.objectOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.number])
-  )
+  passthroughProps: PropTypes.object
 };
 
 Button.defaultProps = {

--- a/src/components/copiable/__tests__/__snapshots__/copiable.test.js.snap
+++ b/src/components/copiable/__tests__/__snapshots__/copiable.test.js.snap
@@ -2,28 +2,34 @@
 
 exports[`basic renders as expected 1`] = `
 <div
-  className="clearfix bg-darken5 round"
+  className="relative clearfix bg-darken5 round"
 >
   <div
-    className="fr py6 px6"
+    className="absolute top right px6 py6"
   >
     <CopyButton
       block={true}
       className="btn btn--xs py3 px3 round"
-      text="the text you copy the text you copy the text you copy the text you copy the text you copy "
+      text="thetextyoucopythetextyoucopythetextyoucopythetext you copy the text you copy "
     />
   </div>
   <div
-    className="py6 px12 txt-mono txt-s"
+    className="py6 px12"
     data-test="copiable-text-el"
     onBlur={[Function]}
     onFocus={[Function]}
     tabIndex="-1"
   >
     <div
-      className="my3"
+      className="my3 txt-mono txt-s mr24"
+      style={
+        Object {
+          "overflowWrap": "break-word",
+          "wordWrap": "break-word",
+        }
+      }
     >
-      the text you copy the text you copy the text you copy the text you copy the text you copy 
+      thetextyoucopythetextyoucopythetextyoucopythetext you copy the text you copy 
     </div>
   </div>
 </div>
@@ -31,28 +37,34 @@ exports[`basic renders as expected 1`] = `
 
 exports[`basic shows copy hint when focused 1`] = `
 <div
-  className="clearfix bg-darken5 round"
+  className="relative clearfix bg-darken5 round"
 >
   <div
-    className="fr py6 px6"
+    className="absolute top right px6 py6"
   >
     <CopyButton
       block={true}
       className="btn btn--xs py3 px3 round"
-      text="the text you copy the text you copy the text you copy the text you copy the text you copy "
+      text="thetextyoucopythetextyoucopythetextyoucopythetext you copy the text you copy "
     />
   </div>
   <div
-    className="py6 px12 txt-mono txt-s"
+    className="py6 px12"
     data-test="copiable-text-el"
     onBlur={[Function]}
     onFocus={[Function]}
     tabIndex="-1"
   >
     <div
-      className="my3"
+      className="my3 txt-mono txt-s mr24"
+      style={
+        Object {
+          "overflowWrap": "break-word",
+          "wordWrap": "break-word",
+        }
+      }
     >
-      the text you copy the text you copy the text you copy the text you copy the text you copy 
+      thetextyoucopythetextyoucopythetextyoucopythetext you copy the text you copy 
     </div>
   </div>
   <Popover

--- a/src/components/copiable/__tests__/copiable-test-cases.js
+++ b/src/components/copiable/__tests__/copiable-test-cases.js
@@ -7,6 +7,16 @@ testCases.basic = {
   component: Copiable,
   props: {
     value:
+      'thetextyoucopythetextyoucopythetextyoucopythetext you copy the text you copy '
+  }
+};
+
+testCases.truncated = {
+  description: 'truncated',
+  component: Copiable,
+  props: {
+    truncated: true,
+    value:
       'the text you copy the text you copy the text you copy the text you copy the text you copy '
   }
 };

--- a/src/components/copiable/examples/copiable-a.js
+++ b/src/components/copiable/examples/copiable-a.js
@@ -9,10 +9,13 @@ export default class Example extends React.Component {
     return (
       <div>
         <div className="mb12">
-          <Copiable value="https://www.mapbox.com/something/special/for/you" />
+          <Copiable value="The length of this copiable text is to illustrate to you how this component's styling works when the text wraps to multiple lines" />
         </div>
         <div>
-          <Copiable value="The length of this copiable text is to illustrate to you how this component's styling works when the text wraps to multiple lines" />
+          <Copiable
+            value="https://www.mapbox.com/something/special/for/you"
+            truncated={true}
+          />
         </div>
       </div>
     );

--- a/src/components/icon/__tests__/icon-test-cases.js
+++ b/src/components/icon/__tests__/icon-test-cases.js
@@ -72,20 +72,4 @@ testCases.inlineLargeDisplay = {
   )
 };
 
-testCases.inlineHeadingDisplay = {
-  description: 'inline txt-h2',
-  element: (
-    <div className="txt-h2">
-      Party because
-      <Icon
-        name="check"
-        themeIcon="mr3 color-green"
-        inline={true}
-        style={{ width: '1em' }}
-      />
-      you did it
-    </div>
-  )
-};
-
 export { testCases };

--- a/src/components/icon/examples/icon-example-options.js
+++ b/src/components/icon/examples/icon-example-options.js
@@ -9,7 +9,6 @@ export default class Example extends React.Component {
     return (
       <Icon
         name="antialias"
-        inlineHeading={true}
         theme={{
           icon: 'icon--l'
         }}

--- a/src/components/popover-trigger/examples/popover-trigger-a.js
+++ b/src/components/popover-trigger/examples/popover-trigger-a.js
@@ -3,6 +3,7 @@ A standard PopoverTrigger.
 */
 import React from 'react';
 import PopoverTrigger from '../popover-trigger';
+import Button from '../../button';
 
 export default class Example extends React.Component {
   getPopoverContent = () => {
@@ -13,9 +14,7 @@ export default class Example extends React.Component {
     return (
       <div>
         <PopoverTrigger content={this.getPopoverContent}>
-          <button type="button" className="btn btn--s btn--purple">
-            Trigger
-          </button>
+          <Button size="medium">Trigger</Button>
         </PopoverTrigger>
       </div>
     );

--- a/src/components/popover-trigger/examples/popover-trigger-b.js
+++ b/src/components/popover-trigger/examples/popover-trigger-b.js
@@ -3,6 +3,7 @@ A PopoverTrigger that opens a dark popover and traps focus inside its content.
 */
 import React from 'react';
 import PopoverTrigger from '../popover-trigger';
+import Button from '../../button';
 
 export default class Example extends React.Component {
   constructor(props) {
@@ -48,9 +49,7 @@ export default class Example extends React.Component {
             'data-test': 'trigger-container'
           }}
         >
-          <button type="button" className="btn btn--s">
-            Trigger
-          </button>
+          <Button size="medium">Trigger</Button>
         </PopoverTrigger>
       </div>
     );

--- a/src/components/popover/__tests__/popover-test-cases.js
+++ b/src/components/popover/__tests__/popover-test-cases.js
@@ -292,7 +292,7 @@ noDisplayCases.allProps = {
     getAnchorElement: () => {},
     children: getPopoverContent(),
     placement: 'left',
-    padding: false,
+    padding: 'none',
     hasPointer: false,
     hideWhenAnchorIsOffscreen: true,
     allowPlacementAxisChange: false,

--- a/src/components/popover/examples/popover-a.js
+++ b/src/components/popover/examples/popover-a.js
@@ -3,6 +3,7 @@ Standard popover.
 */
 import React from 'react';
 import Popover from '../popover';
+import Button from '../../button';
 
 export default class Example extends React.Component {
   constructor(props) {
@@ -49,13 +50,15 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <button
-          ref={this.setAnchor}
+        <Button
           onClick={this.togglePopover}
-          className="btn btn--s"
+          size="medium"
+          passthroughProps={{
+            ref: this.setAnchor
+          }}
         >
           Toggle popover
-        </button>
+        </Button>
         {this.renderPopover()}
       </div>
     );

--- a/src/components/popover/examples/popover-b.js
+++ b/src/components/popover/examples/popover-b.js
@@ -3,6 +3,7 @@ Dark popover.
 */
 import React from 'react';
 import Popover from '../popover';
+import Button from '../../button';
 
 export default class Example extends React.Component {
   constructor(props) {
@@ -50,13 +51,15 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <button
-          ref={this.setAnchor}
+        <Button
           onClick={this.togglePopover}
-          className="btn btn--s"
+          size="medium"
+          passthroughProps={{
+            ref: this.setAnchor
+          }}
         >
           Toggle popover
-        </button>
+        </Button>
         {this.renderPopover()}
       </div>
     );

--- a/src/components/popover/examples/popover-c.js
+++ b/src/components/popover/examples/popover-c.js
@@ -3,6 +3,7 @@ Warning popover.
 */
 import React from 'react';
 import Popover from '../popover';
+import Button from '../../button';
 
 export default class Example extends React.Component {
   constructor(props) {
@@ -50,13 +51,15 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <button
-          ref={this.setAnchor}
+        <Button
           onClick={this.togglePopover}
-          className="btn btn--s"
+          size="medium"
+          passthroughProps={{
+            ref: this.setAnchor
+          }}
         >
           Toggle popover
-        </button>
+        </Button>
         {this.renderPopover()}
       </div>
     );

--- a/src/components/tooltip/examples/tooltip-a.js
+++ b/src/components/tooltip/examples/tooltip-a.js
@@ -3,12 +3,13 @@ A standard tooltip.
 */
 import React from 'react';
 import Tooltip from '../tooltip';
+import Button from '../../button';
 
 export default class Example extends React.Component {
   render() {
     return (
       <Tooltip content="Here's your tooltip">
-        <button className="btn">Basic</button>
+        <Button size="medium">Basic</Button>
       </Tooltip>
     );
   }


### PR DESCRIPTION
A few fixes following up on recent changes:

- Fix text overflow in Copiable, introducing a `truncated` prop to allow for a truncated line of text.
- Consistently use the Button component in new examples that use buttons.
- Clean up some little typos.