### PR TITLE
Add page-footer component

### DIFF
--- a/src/components/page-footer/__tests__/page-footer-test-cases.js
+++ b/src/components/page-footer/__tests__/page-footer-test-cases.js
@@ -1,0 +1,9 @@
+import PageFooter from '../page-footer';
+
+const testCases = {};
+testCases.basic = {
+  description: 'basic',
+  component: PageFooter,
+  props: {}
+};
+export { testCases };

--- a/src/components/page-footer/index.js
+++ b/src/components/page-footer/index.js
@@ -1,0 +1,3 @@
+import main from './page-footer';
+
+export default main;

--- a/src/components/page-footer/page-footer.js
+++ b/src/components/page-footer/page-footer.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class PageFooter extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+    return (
+      <div className="py12 py36-ml">
+        <span className="mr18">© Mapbox</span>
+        <a
+          className="link color-darken50 color-blue-on-hover mr18"
+          href="/tos/"
+        >
+          Terms
+        </a>
+        <a
+          className="link color-darken50 color-blue-on-hover mr18"
+          href="/privacy/"
+        >
+          Privacy
+        </a>
+        <a
+          className="link color-darken50 color-blue-on-hover"
+          href="/platform/security/"
+        >
+          Security
+        </a>
+      </div>
+    );
+  }
+}
+
+PageFooter.propTypes = {
+  className: PropTypes.string
+};
+
+export default PageFooter;


### PR DESCRIPTION
Per discussion, pages moving away from the old page shell will have a dead-simple footer component that only includes our required legal info. App-specific footers can live above this new, legal-only footer. The component in this PR is lifted almost wholesale from the old page shell component. The only changes I made were to translate the page shell-specific classes to assembly classes and to remove the `classNames` prop in favor of the classes we've previously used on marketing pages. 

@davidtheclark for review, please 🙏 