### PR TITLE
Move assembly link to labs.mapbox.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ UI components for Mapbox projects. See docs at https://mapbox.github.io/mr-ui/.
 npm install @mapbox/mr-ui
 ```
 
-On Mapbox projects, pair these components with version 0.26.0+ of Mapbox's custom [Assembly](https://www.mapbox.com/assembly/) build. (This is not in `peerDependencies` because you might use `<link>` and `<script>` tags instead of the npm package.)
+On Mapbox projects, pair these components with version 0.26.0+ of Mapbox's custom [Assembly](https://labs.mapbox.com/assembly/) build. (This is not in `peerDependencies` because you might use `<link>` and `<script>` tags instead of the npm package.)
 
 The public Assembly build should work fine, with maybe one or two hiccups.
 

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -76,7 +76,7 @@ export default class Icon extends React.Component {
 
 Icon.propTypes = {
   /**
-   * The name of the [Assembly icon](https://www.mapbox.com/assembly/icons/) that
+   * The name of the [Assembly icon](https://labs.mapbox.com/assembly/icons/) that
    * you want to display.
    */
   name: PropTypes.string.isRequired,


### PR DESCRIPTION
We are moving Assembly to labs.mapbox.com/assembly. This PR updates the link.