### PR TITLE
Update babel package script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1
+- [fix] Update build script for Babel 7 to fix broken v0.4.0 publication. 
+
 ## 0.4.0
 - [feature] Add **PageHeader** component.
 - [feature] Add **FooterLegalStrip** component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@mapbox/mr-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "UI components for Mapbox projects",
   "main": "index.js",
   "scripts": {

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -25,7 +25,7 @@ const srcDir = path.resolve(rootDir, 'src/components');
 // tests and examples.
 function compileComponents() {
   return execa.shell(
-    `babel "**/!(examples|__tests__)/*.js" --out-dir ${outputDir} --config-file ${rootDir}/babel.config.js`,
+    `babel "${rootDir}/src/components" --out-dir ${outputDir} --ignore "**/examples","**/__tests__" --config-file ${rootDir}/babel.config.js`,
     {
       cwd: srcDir,
       stdio: 'inherit'


### PR DESCRIPTION
It looks like the glob-matching behavior in Babel 7 is a bit different from the old version and our build script wasn't copying each component's parent directory into `pkg`. This PR  uses the `--ignore` flag to exclude `foo/examples/` and `foo/__tests__/` instead of building directory exclusion into the source glob. 

Does this look right to you, @davidtheclark? 