### PR TITLE
Returns chevronous text to display: inline

### DIFF
--- a/src/components/chevronous-text/__tests__/__snapshots__/chevronous-text.test.js.snap
+++ b/src/components/chevronous-text/__tests__/__snapshots__/chevronous-text.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChevronousText basic renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
   Explore
    
   <span
@@ -21,9 +19,7 @@ exports[`ChevronousText basic renders as expected 1`] = `
 `;
 
 exports[`ChevronousText chevron before multiline text renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
   <span
     className="txt-nowrap"
   >
@@ -41,9 +37,7 @@ exports[`ChevronousText chevron before multiline text renders as expected 1`] = 
 `;
 
 exports[`ChevronousText chevron before one long unwrappable word text renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
   <span
     className="txt-nowrap"
   >
@@ -60,9 +54,7 @@ exports[`ChevronousText chevron before one long unwrappable word text renders as
 `;
 
 exports[`ChevronousText multiline text renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
   "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us..." - A Tale of Two
    
   <span
@@ -80,9 +72,7 @@ exports[`ChevronousText multiline text renders as expected 1`] = `
 `;
 
 exports[`ChevronousText one long unwrappable word text renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
    
   <span
     className="txt-nowrap"
@@ -99,9 +89,7 @@ exports[`ChevronousText one long unwrappable word text renders as expected 1`] =
 `;
 
 exports[`ChevronousText sized icon before text renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
   <span
     className="txt-nowrap"
   >
@@ -118,9 +106,7 @@ exports[`ChevronousText sized icon before text renders as expected 1`] = `
 `;
 
 exports[`ChevronousText sized icon renders as expected 1`] = `
-<span
-  className="inline-block"
->
+<span>
    
   <span
     className="txt-nowrap"

--- a/src/components/chevronous-text/chevronous-text.js
+++ b/src/components/chevronous-text/chevronous-text.js
@@ -30,7 +30,7 @@ export default class ChevronousText extends React.PureComponent {
 
     if (iconBefore) {
       return (
-        <span className="inline-block">
+        <span>
           <span className="txt-nowrap">
             <Icon name="chevron-left" inline={true} size={iconSize} />
             {iconWord}
@@ -41,7 +41,7 @@ export default class ChevronousText extends React.PureComponent {
     }
 
     return (
-      <span className="inline-block">
+      <span>
         {textWithoutIconWord}{' '}
         <span className="txt-nowrap">
           {iconWord}


### PR DESCRIPTION
This PR takes chevronous text back to being inline by default. If it needs to go on its own line, it should still be possible to wrap it in a block or inline block element.

Closes #70
@lshig for review