### PR TITLE
[page-loading-indicator] evaluate parentNode before removeChild

### DIFF
--- a/src/components/page-loading-indicator/page-loading-indicator.js
+++ b/src/components/page-loading-indicator/page-loading-indicator.js
@@ -42,7 +42,7 @@ function end() {
       setTimeout(() => {
         mounted = false;
         canEnd = null;
-        el.parentNode.removeChild(el);
+        if (el.parentNode) el.parentNode.removeChild(el);
         el.className = BASE_CLASSNAME;
         resolve();
       }, 300);


### PR DESCRIPTION
This TypeError has been our top error in Sentry and I was finally able to dig in today.

![image](https://user-images.githubusercontent.com/2180540/56060615-61faff80-5d35-11e9-8558-54aaff04793b.png)

```
TypeError
Cannot read property 'removeChild' of null
```


I reproduced the error by running `npm start` and clicking on the component's test page buttons quickly. When the error triggered, `el.parentNode` returned null. This PR evaluates that `el.parentNode` exists before we `removeChild`.

cc @colleenmcginnis 