### PR TITLE
MRC Migration Guide

### DIFF
--- a/docs/mapbox-react-components-migration-guide.md
+++ b/docs/mapbox-react-components-migration-guide.md
@@ -1,0 +1,10 @@
+# Mapbox React Components Migration Guide
+A running document that itemizes the differences between MRC and MR-UI components to aid migrating from one to the other
+
+## Icon
+Passing nested props to the Mr-UI icon will cause `shallowEqualObjects` to throw an error. If you spread props into an icon, you should be doubly aware of this change.
+
+MRC's `themeIcon` prop has been replaced by `passthroughProps.className`.
+
+## Popover
+MRC's `themePopover` prop has been replaced by `passthroughProps.className`.


### PR DESCRIPTION
This PR adds the start of a mapbox react components migration guide that brings in what we learned migrating icons and popovers in studio. We'll continue to update this component-by-component as we migrate them

Closes https://github.com/mapbox/mr-ui/issues/74