### PR TITLE
 Pass the focusTrapPaused prop through to react-aria-modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6296,11 +6296,27 @@
       }
     },
     "focus-trap-react": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-4.0.1.tgz",
-      "integrity": "sha512-UUZKVEn5cFbF6yUnW7lbXNW0iqN617ShSqYKgxctUvWw1wuylLtyVmC0RmPQNnJ/U+zoKc/djb0tZMs0uN/0QQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
+      "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
       "requires": {
-        "focus-trap": "^3.0.0"
+        "focus-trap": "^4.0.2"
+      },
+      "dependencies": {
+        "focus-trap": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+          "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+          "requires": {
+            "tabbable": "^3.1.2",
+            "xtend": "^4.0.1"
+          }
+        },
+        "tabbable": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+          "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
+        }
       }
     },
     "follow-redirects": {
@@ -12564,11 +12580,11 @@
       }
     },
     "react-aria-modal": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/react-aria-modal/-/react-aria-modal-3.0.1.tgz",
-      "integrity": "sha512-H0pV5ITXe6JCQAUGoSiSncfTeGunImT8KFzLLMisuzOzsG4X7GZQJGcjk6uSwZmvwZpHL+EjMwRD+vJZx3nG8g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-aria-modal/-/react-aria-modal-4.0.0.tgz",
+      "integrity": "sha512-crdEAIHc5xXi6YqZeUgRDJN1uromSehU1XSEegVPU8/okmf1tEDwnzb6ULl+PJy4aS6sb6fUiWEdMNTLAX2HBA==",
       "requires": {
-        "focus-trap-react": "^4.0.0",
+        "focus-trap-react": "^6.0.0",
         "no-scroll": "^2.1.1",
         "react-displace": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "hoverintent": "^2.0.0",
     "os-key": "^1.0.0",
     "prefix": "^1.0.0",
-    "react-aria-modal": "^3.0.0",
+    "react-aria-modal": "^4.0.0",
     "react-datepicker": "^0.60.2",
     "react-displace": "^2.3.0",
     "react-submittable": "^2.0.0",

--- a/src/components/modal/__tests__/modal-test-cases.js
+++ b/src/components/modal/__tests__/modal-test-cases.js
@@ -113,6 +113,27 @@ testCases.unpadded = {
   )
 };
 
+testCases.pausedFocusTrap = {
+  description: 'wandering focus',
+  element: (
+    <ModalWrapper
+      componentProps={{
+        accessibleTitle: 'Not focus-trapped',
+        size: 'small',
+        focusTrapPaused: true,
+        children: (
+          <div>
+            <p>You can tab out of this modal. Try it!</p>
+            <p>
+              <a href="#">Some link</a>
+            </p>
+          </div>
+        )
+      }}
+    />
+  )
+};
+
 // Automatable test cases
 
 const noDisplayCases = {};

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -130,6 +130,10 @@ export default class Modal extends React.Component {
       modalProps.focusDialog = true;
     }
 
+    if (props.focusTrapPaused) {
+      modalProps.focusTrapPaused = true;
+    }
+
     return <AriaModal {...modalProps}>{dialogBody}</AriaModal>;
   }
 }
@@ -177,6 +181,13 @@ Modal.propTypes = {
    * `'large'` or `'none'`.
    */
   padding: PropTypes.oneOf(['large', 'none']),
+  /**
+   * If `true`, this will allow interaction with elements outside of the
+   * modal container. You normally don't want to set this, but it can be
+   * useful for nesting different components that are displaced to other
+   * parts of the DOM.
+   */
+  focusTrapPaused: PropTypes.bool,
   /**
    * If `true`, the modal will have the accessibility props of an alert modal.
    * (Only affects screen readers.)


### PR DESCRIPTION
- Bumps `react-aria-modal` to v4.
- Optionally passes through the `focusTrapPaused` prop, along with a note about it's recommended usage.

Close #82 