### PR TITLE
TabList label can be a string or a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## master
+- [feature] Allow `Tablist` label to accept a node.
+
 ## 0.7.3
 - [feature] Allow the **CopyButton** and **Copiable** components to pass through the `focusTrapPaused` prop.
 

--- a/src/components/tab-list/__tests__/__snapshots__/tab-list.test.js.snap
+++ b/src/components/tab-list/__tests__/__snapshots__/tab-list.test.js.snap
@@ -1,5 +1,135 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TabList a label contains a node renders 1`] = `
+<div
+  className="clearfix"
+>
+  <div
+    className="fl"
+    key="0"
+  >
+    <button
+      className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 inline-block border-b border--transparent "
+      data-test="one"
+      key="one"
+      onClick={[Function]}
+      type="button"
+    >
+      <Icon
+        inline={false}
+        name="star"
+        passthroughProps={Object {}}
+        size={18}
+      />
+    </button>
+  </div>
+  <div
+    className="fl"
+    key="1"
+  >
+    <button
+      className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 inline-block border-b border--transparent "
+      data-test="two"
+      key="two"
+      onClick={[Function]}
+      type="button"
+    >
+      Label two
+    </button>
+  </div>
+  <div
+    className="fl"
+    key="0"
+  >
+    <button
+      className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 inline-block-mm none border--blue txt-bold "
+      data-test="three"
+      key="three"
+      onClick={[Function]}
+      type="button"
+    >
+      Label three
+    </button>
+  </div>
+  <div
+    className="fl"
+    key="1"
+  >
+    <button
+      className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 inline-block-mm none border--transparent "
+      data-test="four"
+      key="four"
+      onClick={[Function]}
+      type="button"
+    >
+      Label four
+    </button>
+  </div>
+  <div
+    className="fl"
+  >
+    <PopoverTrigger
+      block={false}
+      content={
+        Array [
+          <div
+            className="block"
+          >
+            <button
+              className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 border-b--0 border--blue txt-bold "
+              data-test="three"
+              onClick={[Function]}
+              type="button"
+            >
+              Label three
+            </button>
+          </div>,
+          <div
+            className="block"
+          >
+            <button
+              className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 border-b--0 border--transparent "
+              data-test="four"
+              onClick={[Function]}
+              type="button"
+            >
+              Label four
+            </button>
+          </div>,
+        ]
+      }
+      disabled={false}
+      onPopoverClose={[Function]}
+      onPopoverOpen={[Function]}
+      popoverProps={
+        Object {
+          "placement": "bottom",
+          "themePopover": "round shadow-darken25 h480 scroll-auto px12 py12 scroll-styled",
+        }
+      }
+      receiveFocus={true}
+      renderHiddenContent={false}
+      respondsToClick={true}
+      respondsToFocus={false}
+      respondsToHover={true}
+      trapFocus={true}
+      triggerProps={
+        Object {
+          "data-test": "more-dropdown-menu",
+        }
+      }
+    >
+      <button
+        className="px6 py12 mr12 align-l cursor-pointer none-mm"
+        type="button"
+      >
+        More +
+      </button>
+    </PopoverTrigger>
+  </div>
+</div>
+`;
+
 exports[`TabList basic renders 1`] = `
 <div
   className="clearfix"

--- a/src/components/tab-list/__tests__/tab-list-test-cases.js
+++ b/src/components/tab-list/__tests__/tab-list-test-cases.js
@@ -1,5 +1,7 @@
+import React from 'react';
 import safeSpy from '../../../test-utils/safe-spy';
 import TabList from '../tab-list';
+import Icon from '../../icon';
 
 const testCases = {};
 
@@ -43,6 +45,21 @@ testCases.truncateAll = {
       { id: 'two', label: 'Label two', href: '#' },
       { id: 'three', label: 'Label three', href: '#' },
       { id: 'four', label: 'Label four', href: '#' }
+    ]
+  }
+};
+
+testCases.labelNode = {
+  description: 'a label contains a node',
+  component: TabList,
+  props: {
+    onChange: safeSpy(),
+    activeItem: 'three',
+    items: [
+      { id: 'one', label: <Icon name="star" /> },
+      { id: 'two', label: 'Label two' },
+      { id: 'three', label: 'Label three' },
+      { id: 'four', label: 'Label four' }
     ]
   }
 };

--- a/src/components/tab-list/__tests__/tab-list.test.js
+++ b/src/components/tab-list/__tests__/tab-list.test.js
@@ -72,4 +72,31 @@ describe('TabList', () => {
       wrapper.update();
     });
   });
+  describe(testCases.labelNode.description, () => {
+    beforeEach(() => {
+      testCase = testCases.labelNode;
+      wrapper = shallow(
+        React.createElement(testCase.component, testCase.props)
+      );
+    });
+
+    test('renders', () => {
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    test('onChange is called', () => {
+      wrapper
+        .find('button')
+        .first()
+        .props()
+        .onClick('one');
+      expect(testCase.props.onChange).toHaveBeenCalledTimes(1);
+      expect(testCase.props.onChange).toHaveBeenCalledWith('one');
+    });
+
+    test('activeItem prop updates active item', () => {
+      wrapper.setProps({ activeItem: 'one' });
+      wrapper.update();
+    });
+  });
 });

--- a/src/components/tab-list/tab-list.js
+++ b/src/components/tab-list/tab-list.js
@@ -10,7 +10,8 @@ export default class TabList extends React.PureComponent {
         /** Identifying value for tab list item. */
         id: PropTypes.string.isRequired,
         /** The name of the tab to be displayed. */
-        label: PropTypes.string.isRequired,
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+          .isRequired,
         /** Determines if the state of the tab list item is active. */
         active: PropTypes.bool,
         /** Link to the page the lab list item should take you to when clicked. */


### PR DESCRIPTION
In /ios and /android we pass a dropdown component as a `label` in the `TabList` component. This PR allows `label` to accept a string or a node.

🐌