### PR TITLE
Destroy clipboard after copy in CopyButton; add CodeSnippet examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 - [feature] Allow **ControlText** `value` to accept a number or a string.
+- [fix] Destroy `Clipboard` after copy in **CopyButton** to prevent exaggerated scroll length in scrolled code snippets.
 
 ## 0.8.0
 - [feature] Add `aria-label` to all components, test cases, and examples with buttons.

--- a/src/components/code-snippet/examples/code-snippet-example-basic.js
+++ b/src/components/code-snippet/examples/code-snippet-example-basic.js
@@ -1,0 +1,19 @@
+/*
+Basic.
+*/
+import React from 'react';
+import CodeSnippet from '../code-snippet';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <CodeSnippet
+        code={`dependencies {
+          compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar') {
+            transitive=true
+          }
+        }`}
+      />
+    );
+  }
+}

--- a/src/components/code-snippet/examples/code-snippet-example-options.js
+++ b/src/components/code-snippet/examples/code-snippet-example-options.js
@@ -1,0 +1,110 @@
+/*
+Set maxHeight and onCopy
+*/
+import React from 'react';
+import CodeSnippet from '../code-snippet';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <CodeSnippet
+        maxHeight={300}
+        onCopy={() => console.log('Copy!')}
+        code={`package com.mapbox.mapboxandroiddemo.examples.basics;
+
+import android.os.Bundle;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+
+/**
+ * The most basic example of adding a map to an activity.
+ */
+public class SimpleMapViewActivity extends AppCompatActivity {
+
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_basic_simple_mapview);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+
+            // Map is set up and the style has loaded. Now you can add data or make other map adjustments.
+
+          }
+        });
+      }
+    });
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}
+`}
+      />
+    );
+  }
+}

--- a/src/components/copy-button/__tests__/copy-button.test.js
+++ b/src/components/copy-button/__tests__/copy-button.test.js
@@ -41,9 +41,11 @@ describe('CopyButton', () => {
     });
 
     test('changes state on click', () => {
+      const destroySpy = jest.spyOn(wrapper.instance(), 'destroyClipboard');
       wrapper.find('button').prop('onClick')();
       wrapper.update();
       expect(wrapper).toMatchSnapshot();
+      expect(destroySpy).toHaveBeenCalled();
       return delay(820).then(() => {
         wrapper.update();
         expect(wrapper).toMatchSnapshot();
@@ -73,9 +75,11 @@ describe('CopyButton', () => {
 
     // Extra classes need to carry over to both states
     test('changes state on click', () => {
+      const destroySpy = jest.spyOn(wrapper.instance(), 'destroyClipboard');
       wrapper.find('button').prop('onClick')();
       wrapper.update();
       expect(wrapper).toMatchSnapshot();
+      expect(destroySpy).toHaveBeenCalled();
       return delay(820).then(() => {
         wrapper.update();
         expect(wrapper).toMatchSnapshot();

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -29,9 +29,7 @@ export default class CopyButton extends React.PureComponent {
 
   componentWillUnmount() {
     clearTimeout(this.revertTimer);
-    if (this.clipboard) {
-      this.clipboard.destroy();
-    }
+    this.destroyClipboard();
   }
 
   handleCopyButtonClick = () => {
@@ -41,6 +39,7 @@ export default class CopyButton extends React.PureComponent {
       onCopy(text);
     }
     this.showFeedback();
+    this.destroyClipboard();
   };
 
   showFeedback = () => {
@@ -55,8 +54,8 @@ export default class CopyButton extends React.PureComponent {
     if (nextProps.textEl !== this.props.textEl && copyAvailable) {
       this.setClipboard(nextProps.textEl);
     }
-    if (!copyAvailable && this.clipboard) {
-      this.clipboard.destroy();
+    if (!copyAvailable) {
+      this.destroyClipboard();
     }
   }
 
@@ -71,6 +70,12 @@ export default class CopyButton extends React.PureComponent {
 
   getContainer = () => {
     return this.container;
+  };
+
+  destroyClipboard = () => {
+    if (this.clipboard) {
+      this.clipboard.destroy();
+    }
   };
 
   setClipboard(element) {


### PR DESCRIPTION
This PR fixes a bug found in the CopyButton, when the CopyButton appears in relative container with a fixed height, after copy there is suddenly a really big scroll on the containing element. This fixes that bug by destroying the clipboard instance after copy.

This PR also adds a couple CodeSnippet examples which were helpful in making a visual check that the bug is fixed.

Fixes #49 