### PR TITLE
Allow ControlText to accept a number or a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## master
+- [feature] Allow **ControlText** `value` to accept a number or a string.
+
 ## 0.8.0
 - [feature] Add `aria-label` to all components, test cases, and examples with buttons.
 
 ## 0.7.4
-- [fix] Allow `Tablist` label to accept a node.
+- [fix] Allow **TabList** label to accept a node.
 
 ## 0.7.3
 - [feature] Allow the **CopyButton** and **Copiable** components to pass through the `focusTrapPaused` prop.

--- a/src/components/control-text/control-text.js
+++ b/src/components/control-text/control-text.js
@@ -44,7 +44,7 @@ export default class ControlText extends React.Component {
      */
     onChange: PropTypes.func.isRequired,
     /** The control's value. Can be an empty string to indicate no value. */
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /** Type attribute to override the existing default of 'text' */
     type: PropTypes.string,
     /** Label for the control. */


### PR DESCRIPTION
Since it's possible to set ControlText's type (such as `number`) - this PR allows the value of ControlText to accept a number or a string.

Ref https://github.com/mapbox/playground/issues/66