### PR TITLE
Fix: initialize Clipboard after it is destroyed so it can be copied again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Master
+- [fix] Initialize `Clipboard` in **CopyButton** after it is destroyed so it can be copied again.
+
 ## 0.9.0
 - [feature] Allow **ControlText** `value` to accept a number or a string.
 - [fix] Destroy `Clipboard` after copy in **CopyButton** to prevent exaggerated scroll length in scrolled code snippets.

--- a/src/components/copy-button/__tests__/copy-button.test.js
+++ b/src/components/copy-button/__tests__/copy-button.test.js
@@ -42,10 +42,14 @@ describe('CopyButton', () => {
 
     test('changes state on click', () => {
       const destroySpy = jest.spyOn(wrapper.instance(), 'destroyClipboard');
-      wrapper.find('button').prop('onClick')();
+      const setClipboardSpy = jest.spyOn(wrapper.instance(), 'setClipboard');
+      wrapper.find('button').prop('onClick')({
+        target: wrapper.find('button')
+      });
       wrapper.update();
       expect(wrapper).toMatchSnapshot();
       expect(destroySpy).toHaveBeenCalled();
+      expect(setClipboardSpy).toHaveBeenCalled();
       return delay(820).then(() => {
         wrapper.update();
         expect(wrapper).toMatchSnapshot();
@@ -76,10 +80,14 @@ describe('CopyButton', () => {
     // Extra classes need to carry over to both states
     test('changes state on click', () => {
       const destroySpy = jest.spyOn(wrapper.instance(), 'destroyClipboard');
-      wrapper.find('button').prop('onClick')();
+      const setClipboardSpy = jest.spyOn(wrapper.instance(), 'setClipboard');
+      wrapper.find('button').prop('onClick')({
+        target: wrapper.find('button')
+      });
       wrapper.update();
       expect(wrapper).toMatchSnapshot();
       expect(destroySpy).toHaveBeenCalled();
+      expect(setClipboardSpy).toHaveBeenCalled();
       return delay(820).then(() => {
         wrapper.update();
         expect(wrapper).toMatchSnapshot();

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -32,14 +32,15 @@ export default class CopyButton extends React.PureComponent {
     this.destroyClipboard();
   }
 
-  handleCopyButtonClick = () => {
+  handleCopyButtonClick = event => {
     // Clipboard.js attaches its own click handlers for copying
     const { onCopy, text } = this.props;
     if (onCopy) {
       onCopy(text);
     }
     this.showFeedback();
-    this.destroyClipboard();
+    this.destroyClipboard(); // destroy clipboard
+    if (event) this.setClipboard(event.target); // reinitialize clipboard
   };
 
   showFeedback = () => {


### PR DESCRIPTION
When we fixed the exaggerated scroll on the CopyButton's click in #105, we introduced a new problem: after the Clipboard is destroyed it can't be copied again.

This PR reinitalizes the Clipboard after it's destroyed.

### Steps to reproduce current bug:
1. Visit https://mapbox.github.io/mr-ui/#codesnippet
2. Click the CopyButton and paste into a textarea. You should see the copied code.
3. Copy and paste "This sentence" and paste into a textarea. You should see "This sentence".
4. Click the same CopyButton from step 2 and paste into a textarea. You should see "This sentence" (but we would expect to see the copied code).

### Steps to confirm current bug is fixed:
1. From this branch, `npm run start-docs`
2. Follow previous steps 2-4. You should see that when you run step 4 that the code _is_ copied.


Fixes #49 (again 😅)
