### PR TITLE
React 16: updating lifecycle methods with unsafe prefix

### DIFF
--- a/src/components/control-file/control-file.js
+++ b/src/components/control-file/control-file.js
@@ -86,7 +86,7 @@ export default class ControlFile extends React.Component {
     displayValue: ''
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const nextDisplayValue = !nextProps.value
       ? ''
       : nextProps.value.map(f => f.name).join(', ');

--- a/src/components/copy-button/copy-button.js
+++ b/src/components/copy-button/copy-button.js
@@ -50,7 +50,7 @@ export default class CopyButton extends React.PureComponent {
     }, FEEDBACK_TIME);
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const copyAvailable = Clipboard.isSupported();
     if (nextProps.textEl !== this.props.textEl && copyAvailable) {
       this.setClipboard(nextProps.textEl);

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -88,7 +88,7 @@ export default class Form extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { config } = this.props;
     if (!shallowEqualObjects(nextProps.config, config)) {
       const {

--- a/src/components/minimum-duration-loader/minimum-duration-loader.js
+++ b/src/components/minimum-duration-loader/minimum-duration-loader.js
@@ -41,7 +41,7 @@ export default class MinimumDurationLoader extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const currentTime = Date.now();
 
     if (!nextProps.isLoaded && this._delayedMountTimeout !== null) {

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -33,7 +33,7 @@ export default class Popover extends React.Component {
     this.popoverId = popoverCounter;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // For focus management: focus will return to this element
     // when the popover is closed
     this.previouslyFocusedElement = document.activeElement;


### PR DESCRIPTION
This adds `UNSAFE__` to lifecycle methods to buy us time before rearchitecting components to move them off these one-day-to-be-deprecated methods.

More background https://reactjs.org/docs/react-component.html

@thefifthisa for review