### PR TITLE
Only render "More +" in tab list when needed

### DIFF
--- a/src/components/tab-list/__tests__/__snapshots__/tab-list.test.js.snap
+++ b/src/components/tab-list/__tests__/__snapshots__/tab-list.test.js.snap
@@ -389,7 +389,7 @@ exports[`TabList links renders 1`] = `
 </div>
 `;
 
-exports[`TabList only show the more+ button if there are more items not currently visible renders 1`] = `
+exports[`TabList only show the more + button if there are more items not currently visible renders 1`] = `
 <div
   className="clearfix"
 >

--- a/src/components/tab-list/__tests__/__snapshots__/tab-list.test.js.snap
+++ b/src/components/tab-list/__tests__/__snapshots__/tab-list.test.js.snap
@@ -389,6 +389,43 @@ exports[`TabList links renders 1`] = `
 </div>
 `;
 
+exports[`TabList only show the more+ button if there are more items not currently visible renders 1`] = `
+<div
+  className="clearfix"
+>
+  <div
+    className="fl"
+    key="0"
+  >
+    <button
+      aria-label="one"
+      className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 inline-block border-b border--blue txt-bold "
+      data-test="one"
+      key="one"
+      onClick={[Function]}
+      type="button"
+    >
+      Label one
+    </button>
+  </div>
+  <div
+    className="fl"
+    key="1"
+  >
+    <button
+      aria-label="two"
+      className="px6 mr24 fl-mm align-center-mm align-l py12 border-b-mm border-b--2 inline-block border-b border--transparent "
+      data-test="two"
+      key="two"
+      onClick={[Function]}
+      type="button"
+    >
+      Label two
+    </button>
+  </div>
+</div>
+`;
+
 exports[`TabList truncate all renders 1`] = `
 <div
   className="clearfix"

--- a/src/components/tab-list/__tests__/tab-list-test-cases.js
+++ b/src/components/tab-list/__tests__/tab-list-test-cases.js
@@ -49,6 +49,20 @@ testCases.truncateAll = {
   }
 };
 
+testCases.moreButtonOnlyIfNeeded = {
+  description:
+    'only show the more+ button if there are more items not currently visible',
+  component: TabList,
+  props: {
+    activeItem: 'one',
+    truncateBy: 2,
+    items: [
+      { id: 'one', label: 'Label one' },
+      { id: 'two', label: 'Label two' }
+    ]
+  }
+};
+
 testCases.labelNode = {
   description: 'a label contains a node',
   component: TabList,

--- a/src/components/tab-list/__tests__/tab-list-test-cases.js
+++ b/src/components/tab-list/__tests__/tab-list-test-cases.js
@@ -51,7 +51,7 @@ testCases.truncateAll = {
 
 testCases.moreButtonOnlyIfNeeded = {
   description:
-    'only show the more+ button if there are more items not currently visible',
+    'only show the more + button if there are more items not currently visible',
   component: TabList,
   props: {
     activeItem: 'one',

--- a/src/components/tab-list/__tests__/tab-list.test.js
+++ b/src/components/tab-list/__tests__/tab-list.test.js
@@ -50,7 +50,7 @@ describe('TabList', () => {
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
-      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
+      expect(wrapper.find({ 'data-test': 'one' }).length).toBe(1);
     });
   });
   describe(testCases.truncateAll.description, () => {
@@ -68,7 +68,7 @@ describe('TabList', () => {
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
-      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
+      expect(wrapper.find({ 'data-test': 'one' }).length).toBe(1);
     });
   });
   describe(testCases.moreButtonOnlyIfNeeded.description, () => {
@@ -86,7 +86,7 @@ describe('TabList', () => {
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
-      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
+      expect(wrapper.find({ 'data-test': 'one' }).length).toBe(1);
     });
   });
   describe(testCases.labelNode.description, () => {
@@ -114,7 +114,7 @@ describe('TabList', () => {
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
-      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
+      expect(wrapper.find({ 'data-test': 'one' }).length).toBe(1);
     });
   });
 });

--- a/src/components/tab-list/__tests__/tab-list.test.js
+++ b/src/components/tab-list/__tests__/tab-list.test.js
@@ -72,6 +72,25 @@ describe('TabList', () => {
       wrapper.update();
     });
   });
+  describe(testCases.moreButtonOnlyIfNeeded.description, () => {
+    beforeEach(() => {
+      testCase = testCases.moreButtonOnlyIfNeeded;
+      wrapper = shallow(
+        React.createElement(testCase.component, testCase.props)
+      );
+    });
+
+    test('renders', () => {
+      expect(
+        toJson(shallow(React.createElement(testCase.component, testCase.props)))
+      ).toMatchSnapshot();
+    });
+
+    test('activeItem prop updates active item', () => {
+      wrapper.setProps({ activeItem: 'one' });
+      wrapper.update();
+    });
+  });
   describe(testCases.labelNode.description, () => {
     beforeEach(() => {
       testCase = testCases.labelNode;

--- a/src/components/tab-list/__tests__/tab-list.test.js
+++ b/src/components/tab-list/__tests__/tab-list.test.js
@@ -32,6 +32,7 @@ describe('TabList', () => {
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
+      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
     });
   });
   describe(testCases.links.description, () => {
@@ -43,14 +44,13 @@ describe('TabList', () => {
     });
 
     test('renders', () => {
-      expect(
-        toJson(shallow(React.createElement(testCase.component, testCase.props)))
-      ).toMatchSnapshot();
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
+      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
     });
   });
   describe(testCases.truncateAll.description, () => {
@@ -62,14 +62,13 @@ describe('TabList', () => {
     });
 
     test('renders', () => {
-      expect(
-        toJson(shallow(React.createElement(testCase.component, testCase.props)))
-      ).toMatchSnapshot();
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
+      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
     });
   });
   describe(testCases.moreButtonOnlyIfNeeded.description, () => {
@@ -81,14 +80,13 @@ describe('TabList', () => {
     });
 
     test('renders', () => {
-      expect(
-        toJson(shallow(React.createElement(testCase.component, testCase.props)))
-      ).toMatchSnapshot();
+      expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
+      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
     });
   });
   describe(testCases.labelNode.description, () => {
@@ -116,6 +114,7 @@ describe('TabList', () => {
     test('activeItem prop updates active item', () => {
       wrapper.setProps({ activeItem: 'one' });
       wrapper.update();
+      expect(wrapper.find('.border--blue.txt-bold').length).toBe(1);
     });
   });
 });

--- a/src/components/tab-list/tab-list.js
+++ b/src/components/tab-list/tab-list.js
@@ -202,7 +202,7 @@ export default class TabList extends React.PureComponent {
       <div className="clearfix">
         {alwaysRenderedItems}
         {sometimesHiddenItems}
-        {moreButton}
+        {truncateBy < items.length && moreButton}
       </div>
     );
   }


### PR DESCRIPTION
Currently, the `moreButton` of the tab list component will always render regardless of whether there are actually any additional items beyond those already visibly enumerated. This PR updates the behavior to only render the button when `truncateBy < items.length`.