### PR TITLE
Set `devServerHistoryFallback: true` to use HTML5 History for client-side routing

### DIFF
--- a/src/test-cases-app/test-cases-app-underreact.config.js
+++ b/src/test-cases-app/test-cases-app-underreact.config.js
@@ -5,6 +5,7 @@ module.exports = () => {
   return {
     siteBasePath: '/', // react-test-kitchen does not currently support configurable basepaths
     jsEntry: path.resolve(__dirname, './index.js'),
-    htmlSource: html
+    htmlSource: html,
+    devServerHistoryFallback: true
   };
 };


### PR DESCRIPTION
This PR enables [devServerHistoryFallback](https://github.com/mapbox/underreact#devserverhistoryfallback) on the test cases app. This solves the problem where when you refresh a test case app component page, the app fails to fetch the route.

## How to test

1. Run `npm start`
2. Click on any component link.
3. Refresh the page, the component test case app should refresh and display properly.