### PR TITLE
Add `inline` prop to IconText component

### DIFF
--- a/src/components/button/__tests__/__snapshots__/button.test.js.snap
+++ b/src/components/button/__tests__/__snapshots__/button.test.js.snap
@@ -92,6 +92,7 @@ exports[`Link with outline and icon text, extra padding renders as expected 1`] 
   <IconText
     gap="small"
     iconBefore="bug"
+    inline={false}
   >
     Go do things
   </IconText>

--- a/src/components/control-file/__tests__/__snapshots__/control-file.test.js.snap
+++ b/src/components/control-file/__tests__/__snapshots__/control-file.test.js.snap
@@ -36,6 +36,7 @@ exports[`ControlFile all options renders 1`] = `
           <IconText
             gap="small"
             iconBefore="harddrive"
+            inline={false}
           >
             Select an image
           </IconText>
@@ -98,6 +99,7 @@ exports[`ControlFile basic receives an array of one file as value, displaying it
           <IconText
             gap="small"
             iconBefore="harddrive"
+            inline={false}
           >
             bon jovi.mp3
           </IconText>
@@ -187,6 +189,7 @@ exports[`ControlFile basic renders 1`] = `
           <IconText
             gap="small"
             iconBefore="harddrive"
+            inline={false}
           >
             Select a file
           </IconText>
@@ -245,6 +248,7 @@ exports[`ControlFile disabled renders 1`] = `
           <IconText
             gap="small"
             iconBefore="harddrive"
+            inline={false}
           >
             Select a file
           </IconText>
@@ -303,6 +307,7 @@ exports[`ControlFile multiple receives an array of files as value, displaying th
           <IconText
             gap="small"
             iconBefore="harddrive"
+            inline={false}
           >
             bon jovi.mp3, aerosmith.mp3
           </IconText>

--- a/src/components/icon-text/__tests__/__snapshots__/icon-text.test.js.snap
+++ b/src/components/icon-text/__tests__/__snapshots__/icon-text.test.js.snap
@@ -78,7 +78,7 @@ exports[`icons on both sides, including a non-string one renders as expected 1`]
 
 exports[`inline flex parent renders as expected 1`] = `
 <span
-  className="flex-parent flex-parent--center-cross"
+  className="flex-parent-inline flex-parent--center-cross"
 >
   <span
     className="flex-child mr3"

--- a/src/components/icon-text/__tests__/__snapshots__/icon-text.test.js.snap
+++ b/src/components/icon-text/__tests__/__snapshots__/icon-text.test.js.snap
@@ -76,6 +76,28 @@ exports[`icons on both sides, including a non-string one renders as expected 1`]
 </span>
 `;
 
+exports[`inline flex parent renders as expected 1`] = `
+<span
+  className="flex-parent flex-parent--center-cross"
+>
+  <span
+    className="flex-child mr3"
+  >
+    <Icon
+      inline={false}
+      name="polyline"
+      passthroughProps={Object {}}
+      size={18}
+    />
+  </span>
+  <span
+    className="flex-child"
+  >
+    Inline!
+  </span>
+</span>
+`;
+
 exports[`large gap renders as expected 1`] = `
 <span
   className="flex-parent flex-parent--center-cross"

--- a/src/components/icon-text/__tests__/icon-text-test-cases.js
+++ b/src/components/icon-text/__tests__/icon-text-test-cases.js
@@ -45,10 +45,24 @@ testCases.bothIcons = {
 testCases.buttonyDisplay = {
   description: 'a buttony look',
   element: (
-    <button aria-label="Duplicate" type="button" className="link txt-bold txt-s block">
+    <button
+      aria-label="Duplicate"
+      type="button"
+      className="link txt-bold txt-s block"
+    >
       <IconText iconBefore="duplicate">Duplicate</IconText>
     </button>
   )
+};
+
+testCases.flexParentInline = {
+  description: 'inline flex parent',
+  component: IconText,
+  props: {
+    children: 'Inline!',
+    iconBefore: 'polyline',
+    inline: true
+  }
 };
 
 export { testCases };

--- a/src/components/icon-text/__tests__/icon-text.test.js
+++ b/src/components/icon-text/__tests__/icon-text.test.js
@@ -48,3 +48,14 @@ describe(testCases.bothIcons.description, () => {
     expect(wrapper).toMatchSnapshot();
   });
 });
+
+describe(testCases.flexParentInline.description, () => {
+  beforeEach(() => {
+    testCase = testCases.flexParentInline;
+    wrapper = shallow(React.createElement(testCase.component, testCase.props));
+  });
+
+  test('renders as expected', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/icon-text/icon-text.js
+++ b/src/components/icon-text/icon-text.js
@@ -18,6 +18,7 @@ class IconText extends React.Component {
   render() {
     const { props } = this;
     const spacer = props.gap === 'small' ? '3' : '6';
+    const inline = props.inline ? '-inline' : '';
 
     const before = !props.iconBefore ? null : (
       <span className={`flex-child mr${spacer}`}>
@@ -32,7 +33,7 @@ class IconText extends React.Component {
     );
 
     return (
-      <span className="flex-parent flex-parent--center-cross">
+      <span className={`flex-parent${inline} flex-parent--center-cross`}>
         {before}
         <span className="flex-child">{props.children}</span>
         {after}
@@ -61,11 +62,17 @@ IconText.propTypes = {
   /**
    * An icon to place after the text. See details documented for `iconBefore`.
    */
-  iconAfter: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+  iconAfter: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /**
+   * A boolean indicating whether the component's wrapper element should be
+   * 'flex-parent' (false) or 'flex-parent-inline' (true).
+   */
+  inline: PropTypes.bool
 };
 
 IconText.defaultProps = {
-  gap: 'small'
+  gap: 'small',
+  inline: false
 };
 
 export default IconText;


### PR DESCRIPTION
This PR adds an optional `inline` prop to the `IconText` component, with a default value of `false`. When set to `true`, the outer `<span>` wrapping the component will have a class of `'flex-parent-inline'` rather than the default `'flex-parent'`. This change will allow the `IconText` component to be horizontally centered as expected when used as the child of an element with class `'align-center'`.

Note that one can't get around this (though please do correct me if I'm wrong!) by adding a `className` prop with a value set to `'mx-auto'` since the outer `<span>` still would have `display: inline`.