### PR TITLE
Update mbx-assembly@1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,9 +1046,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001230",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-          "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+          "version": "1.0.30001235",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
+          "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
           "dev": true
         },
         "coa": {
@@ -1100,15 +1100,15 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.739",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
-          "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
+          "version": "1.3.749",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
+          "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
           "dev": true
         },
         "es-abstract": {
-          "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
-          "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -1185,9 +1185,9 @@
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.72",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
-          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+          "version": "1.1.73",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+          "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
           "dev": true
         },
         "object-inspect": {
@@ -1215,15 +1215,14 @@
           }
         },
         "object.values": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-          "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+          "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.18.0-next.2",
-            "has": "^1.0.3"
+            "es-abstract": "^1.18.2"
           }
         },
         "postcss": {
@@ -1420,9 +1419,9 @@
       }
     },
     "@mapbox/mbx-assembly": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mbx-assembly/-/mbx-assembly-1.0.1.tgz",
-      "integrity": "sha512-WB2mgJ9/L+zsXYvRITVL0HWRnfMqAZg3x1hRyy/lozWAzy33o+DLzNl0kHtzq6Wv34DgajAaThinYU/3Qd1gmQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mbx-assembly/-/mbx-assembly-1.1.0.tgz",
+      "integrity": "sha512-/xNAwCCNKfJ8xMAOgXWF0sK3HVmXYCklN3idRI6ve/WQUZF7DkTs2poj+MvBrCyYWPfNuuRvCARpxua8lFL9LQ==",
       "dev": true,
       "requires": {
         "@mapbox/assembly": "1.2.1",
@@ -1460,21 +1459,21 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001230",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
-          "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+          "version": "1.0.30001235",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
+          "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.739",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
-          "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
+          "version": "1.3.749",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.749.tgz",
+          "integrity": "sha512-F+v2zxZgw/fMwPz/VUGIggG4ZndDsYy0vlpthi3tjmDZlcfbhN5mYW0evXUsBr2sUtuDANFtle410A9u/sd/4A==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.72",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
-          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+          "version": "1.1.73",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+          "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
           "dev": true
         },
         "postcss": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-react": "^7.0.0",
     "@mapbox/eslint-config-mapbox": "^1.2.1",
     "@mapbox/jsxtreme-markdown": "^0.9.3",
+    "@mapbox/mbx-assembly": "^1.1.0",
     "@mapbox/react-test-kitchen": "^0.3.0",
     "@mapbox/underreact": "^0.3.0",
     "babel-core": "^7.0.0-bridge.0",
@@ -104,7 +105,6 @@
     "react-dom": "^16.4.1",
     "react-helmet": "^5.2.0",
     "react-test-renderer": "^16.4.1",
-    "regenerator-runtime": "^0.12.1",
-    "@mapbox/mbx-assembly": "1.0.1"
+    "regenerator-runtime": "^0.12.1"
   }
 }


### PR DESCRIPTION
This PR bumps mbx-assembly@1.1.0. This release updates the `gray` color to be reflected under the Core colors section of the mr-ui site.

<img width="950" alt="2021-06-08 at 8 26 AM" src="https://user-images.githubusercontent.com/2180540/121184661-4e735280-c833-11eb-85fd-df574ca8cce1.png">