### PR TITLE
Consistify inline error handling to Studio conventions

### DIFF
--- a/src/components/control-text/__tests__/__snapshots__/control-text.test.js.snap
+++ b/src/components/control-text/__tests__/__snapshots__/control-text.test.js.snap
@@ -19,8 +19,6 @@ exports[`ControlText all options renders 1`] = `
   <div
     className="flex"
     data-test="control-text-container"
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
   >
     <input
       aria-invalid={true}
@@ -32,9 +30,7 @@ exports[`ControlText all options renders 1`] = `
       data-test="testinput-input"
       id="testinput"
       name="testinput"
-      onBlur={[Function]}
       onChange={[Function]}
-      onFocus={[Function]}
       placeholder="Enter an email address"
       popoverProps={
         Object {
@@ -43,11 +39,6 @@ exports[`ControlText all options renders 1`] = `
         }
       }
       spellCheck={false}
-      style={
-        Object {
-          "boxShadow": "inset 0 0 0 1px #f74e4e",
-        }
-      }
       type="email"
       value="foo@bar.baz"
     />
@@ -57,7 +48,14 @@ exports[`ControlText all options renders 1`] = `
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
+      onMouseOut={[Function]}
+      onMouseOver={[Function]}
       role="alert"
+      style={
+        Object {
+          "boxShadow": "-1px 0 0 0 #EB1414",
+        }
+      }
       type="button"
     >
       <span
@@ -189,8 +187,6 @@ exports[`ControlText error inline option renders 1`] = `
   <div
     className="flex"
     data-test="control-text-container"
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
   >
     <input
       aria-invalid={true}
@@ -199,14 +195,7 @@ exports[`ControlText error inline option renders 1`] = `
       data-test="testinput-input"
       id="testinput"
       name="testinput"
-      onBlur={[Function]}
       onChange={[Function]}
-      onFocus={[Function]}
-      style={
-        Object {
-          "boxShadow": "inset 0 0 0 1px #f74e4e",
-        }
-      }
       type="text"
       value=""
     />
@@ -216,7 +205,14 @@ exports[`ControlText error inline option renders 1`] = `
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
+      onMouseOut={[Function]}
+      onMouseOver={[Function]}
       role="alert"
+      style={
+        Object {
+          "boxShadow": "-1px 0 0 0 #EB1414",
+        }
+      }
       type="button"
     >
       <span

--- a/src/components/control-text/__tests__/control-text.test.js
+++ b/src/components/control-text/__tests__/control-text.test.js
@@ -95,26 +95,6 @@ describe('ControlText', () => {
       ).toMatchSnapshot();
     });
 
-    test('popover toggles on input focus/blur states', () => {
-      expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
-        false
-      );
-
-      wrapper.find('input').last().props().onFocus();
-
-      wrapper.update();
-      expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
-        true
-      );
-
-      wrapper.find('input').last().props().onBlur();
-
-      wrapper.update();
-      expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
-        false
-      );
-    });
-
     test('popover toggles on button focus/blur states', () => {
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
         false
@@ -135,22 +115,19 @@ describe('ControlText', () => {
       );
     });
 
-    test('popover toggles on container mouseOver/mouseOut states', () => {
+    test('popover toggles on button mouseOver/mouseOut states', () => {
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
         false
       );
 
-      wrapper
-        .find('[data-test="control-text-container"]')
-        .props()
-        .onMouseOver();
+      wrapper.find('button').last().props().onMouseOver();
 
       wrapper.update();
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
         true
       );
 
-      wrapper.find('[data-test="control-text-container"]').props().onMouseOut();
+      wrapper.find('button').last().props().onMouseOut();
 
       wrapper.update();
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
@@ -170,21 +147,21 @@ describe('ControlText', () => {
       });
     });
 
-    test('popover toggles on container mouseOver/mouseOut states', () => {
+    test('popover toggles on button mouseOver/mouseOut states', () => {
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
         false
       );
 
-      const inputEl = getWindow().document.activeElement;
-      wrapper.instance().setInputElement(inputEl);
+      const errorEl = getWindow().document.activeElement;
+      wrapper.instance().setErrorElement(errorEl);
       wrapper.instance().onFocus();
-      wrapper.update();
 
+      wrapper.update();
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(
         true
       );
 
-      wrapper.find('[data-test="control-text-container"]').props().onMouseOut();
+      wrapper.find('button').last().props().onMouseOut();
 
       wrapper.update();
       expect(wrapper.find('[data-test="popover-component"]').exists()).toBe(

--- a/src/components/control-text/control-text.js
+++ b/src/components/control-text/control-text.js
@@ -98,6 +98,10 @@ export default class ControlText extends React.Component {
     };
   }
 
+  setInputElement = (el) => {
+    this.inputElement = el;
+  };
+
   setErrorElement = (el) => {
     this.errorElement = el;
   };
@@ -216,7 +220,7 @@ export default class ControlText extends React.Component {
       if (validationError) {
         control = (
           <div data-test="control-text-container" className="flex">
-            <input {...inputProps} {...extraProps} />
+            <input ref={this.setInputElement} {...inputProps} {...extraProps} />
             <button
               type="button"
               ref={this.setErrorElement}

--- a/src/components/control-text/control-text.js
+++ b/src/components/control-text/control-text.js
@@ -6,6 +6,7 @@ import ControlWrapper from '../control-wrapper';
 import Popover from '../popover';
 import Icon from '../icon';
 import getWindow from '../utils/get-window';
+import assemblyCssVariables from '@mapbox/mbx-assembly/dist/variables.json';
 
 const propNames = [
   'id',
@@ -97,10 +98,6 @@ export default class ControlText extends React.Component {
     };
   }
 
-  setInputElement = (el) => {
-    this.inputElement = el;
-  };
-
   setErrorElement = (el) => {
     this.errorElement = el;
   };
@@ -117,23 +114,20 @@ export default class ControlText extends React.Component {
     this.setState({ popoverOpen: true });
   };
 
+  isActive = () => {
+    return getWindow().document.activeElement === this.errorElement;
+  };
+
   onBlur = () => {
     this.setState({ popoverOpen: false });
   };
 
-  isActive = () => {
-    return (
-      getWindow().document.activeElement === this.inputElement ||
-      getWindow().document.activeElement === this.errorElement
-    );
-  };
-
-  onContainerMouseOver = () => {
+  onMouseOver = () => {
     if (this.isActive()) return;
     this.setState({ popoverOpen: true });
   };
 
-  onContainerMouseOut = () => {
+  onMouseOut = () => {
     if (this.isActive()) return;
     this.setState({ popoverOpen: false });
   };
@@ -210,9 +204,6 @@ export default class ControlText extends React.Component {
 
     if (validationError && errorStyle === 'inline') {
       inputProps.className = `${themeControlInput} round-l flex-child-grow`;
-      inputProps.style = {
-        boxShadow: 'inset 0 0 0 1px #f74e4e'
-      };
     }
 
     const labelElement = label ? this.renderLabel() : null;
@@ -224,28 +215,22 @@ export default class ControlText extends React.Component {
     if (errorStyle === 'inline') {
       if (validationError) {
         control = (
-          <div
-            onMouseOver={this.onContainerMouseOver}
-            onMouseOut={this.onContainerMouseOut}
-            data-test="control-text-container"
-            className="flex"
-          >
-            <input
-              ref={this.setInputElement}
-              onFocus={this.onFocus}
-              onBlur={this.onBlur}
-              {...inputProps}
-              {...extraProps}
-            />
+          <div data-test="control-text-container" className="flex">
+            <input {...inputProps} {...extraProps} />
             <button
               type="button"
+              ref={this.setErrorElement}
               onFocus={this.onFocus}
               onBlur={this.onBlur}
-              ref={this.setErrorElement}
               onClick={this.onErrorClick}
+              onMouseOver={this.onMouseOver}
+              onMouseOut={this.onMouseOut}
               role="alert"
               aria-label={validationError}
               className="bg-red color-white round-r px6"
+              style={{
+                boxShadow: `-1px 0 0 0 ${assemblyCssVariables['red']}`
+              }}
             >
               <span className="flex flex--center-cross flex--center-main">
                 <Icon name="alert" themeIcon="cursor-pointer" />


### PR DESCRIPTION
Previously the whole element would display the tooltip which resulted in a popup positioner error if a validation error was no longer present after typing. This conforms to Studio behavior where the error is discoverable from the alert button.