### PR TITLE
fix copy button ssr bug

### DIFF
--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -173,5 +173,5 @@ CopyButton.propTypes = {
 };
 
 CopyButton.isCopySupported = () => {
-  return Clipboard.isSupported();
+  return typeof window === 'undefined' ? false : Clipboard.isSupported();
 };


### PR DESCRIPTION
Fixes a bug we encountered while attempting to upgrade `dr-ui` to use the latest version of `mr-ui`.

The `CopyButton` component makes use of `clipboard.js` which expects to run in the browser and references `document`.  When attempting to build the `dr-ui` docs, batfish attempts to create static pages and the build fails while trying to render static content for `CodeSnippet`, which uses `CopyButton`.

CodeSnippet actually does a check for `isCopySupported()` before attempting to render `CopyButton`, so this is an ideal place to also check whether the code is running in a browser.  

With this change, if there is no browser `CopyButton.isCopySupported()` returns `false`, `CopyButton` is never rendered, and SSR can proceed without issue.