### PR TITLE
BILLING-576: MinimumDurationLoader mounts twice if loading finishes before MinDuration has passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## 2.6.2
+
+- [bug] `MinimumDurationLoader` mounts the underlying components twice if `minDuration` is reached before `isLoaded` is set to `true`.
+
 ## 2.6.1
 
 - [fix] Incorrect directory was published to npm as 2.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.6.2-dev.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mr-ui",
-      "version": "2.6.2-dev.1",
+      "version": "2.6.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.6.1",
+  "version": "2.6.2-dev.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mr-ui",
-      "version": "2.6.1",
+      "version": "2.6.2-dev.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.6.1",
+  "version": "2.6.2-dev.1",
   "description": "UI components for Mapbox projects",
   "main": "index.js",
   "homepage": "./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.6.2-dev.1",
+  "version": "2.6.2",
   "description": "UI components for Mapbox projects",
   "main": "index.js",
   "homepage": "./",

--- a/src/components/minimum-duration-loader/minimum-duration-loader.test.tsx
+++ b/src/components/minimum-duration-loader/minimum-duration-loader.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import MinimumDurationLoader from './minimum-duration-loader';
 
 const children = <span data-testid='test-content'>Content</span>;
@@ -37,7 +37,7 @@ describe('MinimumDurationLoader', () => {
       expect(screen.getByTestId('minimum-duration-loader')).toBeInTheDocument();
       expect(screen.queryByTestId('test-content')).not.toBeInTheDocument();
 
-      jest.advanceTimersByTime(1000);
+     act(() => jest.advanceTimersByTime(1000));
 
       expect(screen.queryByTestId('minimum-duration-loader')).not.toBeInTheDocument();
       expect(screen.getByTestId('test-content')).toBeInTheDocument();
@@ -46,11 +46,11 @@ describe('MinimumDurationLoader', () => {
     test.skip('does not render the content if isLoaded becomes `false` after having been `true`', () => {
       const { rerender } = render(<MinimumDurationLoader {...{...props, isLoaded: true}} />)
       expect(screen.getByTestId('minimum-duration-loader')).toBeInTheDocument();
-      jest.advanceTimersByTime(1000);
+      act(() => jest.advanceTimersByTime(1000));
       expect(screen.getByTestId('test-content')).toBeInTheDocument();
       rerender(<MinimumDurationLoader {...props } />)
       expect(screen.getByTestId('minimum-duration-loader')).toBeInTheDocument();
-      jest.advanceTimersByTime(1000);
+      act(() => jest.advanceTimersByTime(1000));
       expect(screen.getByTestId('test-content')).toBeInTheDocument();
     });
   });
@@ -104,11 +104,11 @@ describe('MinimumDurationLoader', () => {
       // Loader should exist
       expect(screen.getByTestId('minimum-duration-loader')).toBeInTheDocument();
       expect(screen.queryByTestId('test-content')).not.toBeInTheDocument();
-      jest.advanceTimersByTime(1000);
+      act(() => jest.advanceTimersByTime(1000));
       // Loader should still exist because we exceeded the minimum duration
       expect(screen.getByTestId('minimum-duration-loader')).toBeInTheDocument();
       expect(screen.queryByTestId('test-content')).not.toBeInTheDocument();
-      jest.advanceTimersByTime(4000);
+      act(() => jest.advanceTimersByTime(4000));
       // We've exceeded the minimum duration, so the loader should not exist
       expect(screen.queryByTestId('minimum-duration-loader')).not.toBeInTheDocument();
       expect(screen.getByTestId('test-content')).toBeInTheDocument();

--- a/src/components/minimum-duration-loader/minimum-duration-loader.tsx
+++ b/src/components/minimum-duration-loader/minimum-duration-loader.tsx
@@ -65,7 +65,7 @@ export default function MinimumDurationLoader({
     isLoaded
   ]);
 
-  const shouldRenderContent = isLoaded && (wasLoaded || delayedLoaded);
+  const shouldRenderContent = isLoaded && (wasLoaded || delayedLoaded || prevIsLoaded);
 
   if (shouldRenderContent) {
     return (


### PR DESCRIPTION
Fixes a bug that happens when `isLoaded` is set to `true` before `minDuration` has passed. In this scenario, the `children` will get mounted twice.

I observed that `shouldRenderContent` essentially flip-flops between `true` and `false` causing unnecessary unmount / remount. The relevant pieces of state look like this
```
Initial: isLoaded=false, wasLoaded=false, delayedLoaded=false          -> shouldRenderContent=false
First mount: isLoaded=true, wasLoaded=false, delayedLoaded=true        -> shouldRenderContent=true
Immediately after: isLoaded=true, wasLoaded=false, delayedLoaded=false -> shouldRenderContent=false
Followed by: isLoaded=true, wasLoaded=false, delayedLoaded=true        -> shouldRenderContent=true
```

The best fix here would most likely be the figure out what causes this flip-flopping. However, the component is quite difficult to follow and the intended behavior seems to be to render the `children` exactly once anyway. Thus, I fixed this by considering `prevIsLoaded` too when deciding the value for `shouldRenderContent`

In most cases, this is probably at most a small performance issue but this bug surfaced when Billing team noticed that account dashboard actually has some components with side-effects during mount (e.g. when verifying email address). Since we depend quite heavily on the `MinimumDurationLoader`, I figured that fixing the bug here makes sense, despite having side-effects occur during mount is also pretty dirty.