### PR TITLE
Optimize tooltip in Control range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+## 2.19.2
+- [bug] Fixes tooltip hanging behind in ControlRange when dragging slider very fast
+
 ## 2.19.1
 - [bug] Bad published build of pkg
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.19.2",
+  "version": "2.19.2-dev.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mr-ui",
-      "version": "2.19.2",
+      "version": "2.19.2-dev.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.19.2-dev.4",
+  "version": "2.19.2-dev.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mr-ui",
-      "version": "2.19.2-dev.4",
+      "version": "2.19.2-dev.5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mr-ui",
-      "version": "2.19.1",
+      "version": "2.19.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "UI components for Mapbox projects",
   "main": "index.js",
   "homepage": "./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.19.2",
+  "version": "2.19.2-dev.4",
   "description": "UI components for Mapbox projects",
   "main": "index.js",
   "homepage": "./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.19.2-dev.4",
+  "version": "2.19.2-dev.5",
   "description": "UI components for Mapbox projects",
   "main": "index.js",
   "homepage": "./",

--- a/src/components/control-range/control-range.tsx
+++ b/src/components/control-range/control-range.tsx
@@ -3,10 +3,12 @@ import React, {
   ReactNode,
   useState,
   useCallback,
-  useMemo
+  useMemo,
+  useRef,
+  useEffect
 } from 'react';
+import { createPortal } from 'react-dom';
 import * as SliderPrimitive from '@radix-ui/react-slider';
-import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
 import PropTypes from 'prop-types';
 import omit from '../utils/omit';
@@ -71,6 +73,9 @@ export default function ControlRange({
 }: Props): ReactElement {
   const extraProps = omit(props, propNames);
   const [activeThumbIndex, setActiveThumbIndex] = useState<number | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const thumbRefs = useRef<(HTMLSpanElement | null)[]>([]);
 
   const tooltipTheme = useMemo(() => {
     if (!tooltip) return null;
@@ -82,6 +87,25 @@ export default function ControlRange({
       shadowColor
     };
   }, [tooltip, themeTooltipColoring]);
+
+  const updateTooltipPosition = useCallback((thumbElement: HTMLElement) => {
+    const thumbRect = thumbElement.getBoundingClientRect();
+
+    setTooltipPosition({
+      x: thumbRect.left + thumbRect.width / 2,
+      y: thumbRect.top - 44
+    });
+  }, []);
+
+  useEffect(() => {
+    if (activeThumbIndex !== null && thumbRefs.current[activeThumbIndex]) {
+      const thumbElement = thumbRefs.current[activeThumbIndex];
+      if (thumbElement) {
+        updateTooltipPosition(thumbElement);
+      }
+    }
+  }, [activeThumbIndex, value, updateTooltipPosition]);
+
 
   const rootProps = {
     id,
@@ -99,45 +123,20 @@ export default function ControlRange({
 
   const renderThumb = useCallback(
     (thumbValue: number, index: number) => {
-      if (tooltip && tooltipTheme) {
-        const { tooltipClasses, fill, shadowColor } = tooltipTheme;
-
-        return (
-          <TooltipPrimitive.Root key={index} open={activeThumbIndex === index}>
-            <TooltipPrimitive.Trigger asChild>
-              <SliderPrimitive.Thumb
-                className={`${themeControlThumb}`}
-                onMouseOver={() => setActiveThumbIndex(index)}
-                onMouseOut={() => setActiveThumbIndex(null)}
-                onPointerCancel={() => setActiveThumbIndex(null)}
-              />
-            </TooltipPrimitive.Trigger>
-            <TooltipPrimitive.Content
-              side="top"
-              align="center"
-              sideOffset={6}
-              className={tooltipClasses}
-              style={{
-                filter: `drop-shadow(0 0 4px ${shadowColor})`
-              }}
-            >
-              {thumbValue}
-              <TooltipPrimitive.Arrow
-                width={12}
-                height={6}
-                offset={6}
-                fill={fill}
-              />
-            </TooltipPrimitive.Content>
-          </TooltipPrimitive.Root>
-        );
-      }
-
       return (
-        <SliderPrimitive.Thumb key={index} className={`${themeControlThumb}`} />
+        <SliderPrimitive.Thumb
+          key={index}
+          ref={(el) => {
+            thumbRefs.current[index] = el;
+          }}
+          className={`${themeControlThumb}`}
+          onMouseOver={() => setActiveThumbIndex(index)}
+          onMouseOut={() => setActiveThumbIndex(null)}
+          onPointerCancel={() => setActiveThumbIndex(null)}
+        />
       );
     },
-    [tooltip, tooltipTheme, activeThumbIndex, themeControlThumb]
+    [themeControlThumb]
   );
 
   return (
@@ -155,18 +154,45 @@ export default function ControlRange({
           themeLabel={themeLabel}
         />
       )}
-      <div className={`range ${themeControlRange}`}>
-        <TooltipPrimitive.Provider delayDuration={0}>
-          <SliderPrimitive.Root {...rootProps}>
-            <SliderPrimitive.Track className={`${themeControlTrack}`}>
-              <SliderPrimitive.Range
-                className={`absolute h-full ${themeControlRangeActive}`}
-              />
-            </SliderPrimitive.Track>
-            {value.map(renderThumb)}
-          </SliderPrimitive.Root>
-        </TooltipPrimitive.Provider>
+      <div className={`range ${themeControlRange}`} ref={sliderRef}>
+        <SliderPrimitive.Root {...rootProps}>
+          <SliderPrimitive.Track className={`${themeControlTrack}`}>
+            <SliderPrimitive.Range
+              className={`absolute h-full ${themeControlRangeActive}`}
+            />
+          </SliderPrimitive.Track>
+          {value.map(renderThumb)}
+        </SliderPrimitive.Root>
       </div>
+      {tooltip && activeThumbIndex !== null && tooltipTheme && createPortal(
+        <div
+          className={`fixed ${tooltipTheme.tooltipClasses}`}
+          style={{
+            left: tooltipPosition.x,
+            top: tooltipPosition.y,
+            transform: 'translateX(-50%)',
+            filter: `drop-shadow(0 0 4px ${tooltipTheme.shadowColor})`,
+            pointerEvents: 'none',
+            zIndex: 9999
+          }}
+        >
+          {value[activeThumbIndex]}
+          <div
+            className="absolute"
+            style={{
+              bottom: '-6px',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: 0,
+              height: 0,
+              borderLeft: '6px solid transparent',
+              borderRight: '6px solid transparent',
+              borderTop: `6px solid ${tooltipTheme.fill}`
+            }}
+          />
+        </div>,
+        document.body
+      )}
     </ControlWrapper>
   );
 }


### PR DESCRIPTION
Seems that popup primitive has to make more calculations about where the popup should be shown, slowing down the display of the tooltip. It sometimes hanged behind when the user was dragging the slider fast. Using TooltipPrimitive instead of PopupPrimitive makes the tooltip much more responsive and fast. 

This becomes apparent when using ControlRange in a more complex application. 

Before:

https://github.com/user-attachments/assets/434ea0de-2161-4e3b-8893-b3e8e7654e52

After:
