### PR TITLE
Add `tooltipContent` prop to `CopyButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## 2.23.0
+
+- [feature] Add `tooltipContent` prop to `CopyButton` for customizing the tooltip text and `aria-label`. Defaults to `'Copy'`.
+
 ## 2.22.0
 
 - [feature] Add support for React 19 as a peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mr-ui",
-      "version": "2.22.0",
+      "version": "2.23.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mbx-assembly": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "UI components for Mapbox projects",
   "sideEffects": false,
   "homepage": "./",

--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -16,6 +16,7 @@ interface Props {
   className?: string;
   tooltipColoring?: 'light' | 'dark';
   tooltipTextSize?: 'xs' | 's' | 'none';
+  tooltipContent?: string;
   children?: ReactNode;
   passthroughProps?: HTMLAttributes<HTMLButtonElement>;
 }
@@ -37,6 +38,7 @@ export default function CopyButton({
   children,
   tooltipColoring = 'light',
   tooltipTextSize = 's',
+  tooltipContent = 'Copy',
   passthroughProps
 }: Props): ReactElement {
   const [clipboard, setClipboard] = useState(null);
@@ -124,7 +126,7 @@ export default function CopyButton({
   return (
     <div
       role="button"
-      aria-label="Copy"
+      aria-label={tooltipContent}
       data-testid="copy-button"
       ref={ref => setClipboardElement(ref)}
       data-clipboard-text={text}
@@ -144,7 +146,7 @@ export default function CopyButton({
             disabled={showingFeedback}
             coloring={tooltipColoring}
             textSize={tooltipTextSize}
-            content="Copy"
+            content={tooltipContent}
           >
             {body}
           </Tooltip>
@@ -196,6 +198,11 @@ CopyButton.propTypes = {
    * `'xs'` (extra small), `'s'` (small), or `'none'` (no size class).
    */
   tooltipTextSize: PropTypes.oneOf(['xs', 's', 'none']),
+  /**
+   * The text shown in the tooltip and used as the button's `aria-label`.
+   * Defaults to `'Copy'`.
+   */
+  tooltipContent: PropTypes.string,
   /** Optional content to represent the button. */
   children: PropTypes.node
 };

--- a/src/components/copy-button/examples/copy-button-c.tsx
+++ b/src/components/copy-button/examples/copy-button-c.tsx
@@ -7,7 +7,7 @@ import CopyButton from '../copy-button';
 export default function Example() {
   return (
     <div className="inline-block">
-      <CopyButton tooltipColoring="dark" tooltipTextSize="xs" text="Some copy from the custom element">
+      <CopyButton tooltipColoring="dark" tooltipTextSize="xs" tooltipContent="Copy snippet" text="Some copy from the custom element">
         <button className="w240 btn">Just a custom element</button>
       </CopyButton>
     </div>


### PR DESCRIPTION
Adds an optional `tooltipContent` prop to the CopyButton component. This will come in useful for copying the source layer ID within the data workbench editor.

| Before | After |
| --- | --- |
| <img width="1512" height="945" alt="Screenshot 2026-04-28 at 4 15 11 PM" src="https://github.com/user-attachments/assets/379c29ca-d81f-4cae-818c-4700bf1c9f60" /> | <img width="1512" height="945" alt="Screenshot 2026-04-28 at 4 12 26 PM" src="https://github.com/user-attachments/assets/0b0d2a1a-fab2-426e-a655-9dbe1b6baf71" /> |

