### PR TITLE
Support a custom label display for ControlSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## 2.24.0
+
+- [feature] Add optional `children` prop to `ControlSelect`. When provided, the native select is hidden and positioned absolutely over the children, which are rendered as a custom display with pointer-events disabled.
+
 ## 2.23.0
 
 - [feature] Add `tooltipContent` prop to `CopyButton` for customizing the tooltip text and `aria-label`. Defaults to `'Copy'`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mr-ui",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "UI components for Mapbox projects",
   "sideEffects": false,
   "homepage": "./",

--- a/src/components/control-select/__snapshots__/control-select.test.tsx.snap
+++ b/src/components/control-select/__snapshots__/control-select.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`ControlSelect basic renders 1`] = `
         </label>
       </div>
       <div
-        class="select-container "
+        class="select-container"
       >
         <select
           aria-required="true"
@@ -137,7 +137,7 @@ exports[`ControlSelect disabled renders 1`] = `
         </label>
       </div>
       <div
-        class="select-container "
+        class="select-container"
       >
         <select
           aria-required="true"
@@ -185,7 +185,7 @@ exports[`ControlSelect grouped dropdown options renders 1`] = `
         </label>
       </div>
       <div
-        class="select-container "
+        class="select-container"
       >
         <select
           aria-required="true"
@@ -251,7 +251,7 @@ exports[`ControlSelect supported values renders 1`] = `
         </label>
       </div>
       <div
-        class="select-container "
+        class="select-container"
       >
         <select
           aria-required="true"
@@ -278,6 +278,50 @@ exports[`ControlSelect supported values renders 1`] = `
         <div
           class="select-arrow"
         />
+      </div>
+      <div
+        role="alert"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ControlSelect with children renders 1`] = `
+<body>
+  <div>
+    <div
+      class="relative "
+    >
+      <div
+        class="select-container relative"
+      >
+        <select
+          aria-required="true"
+          class="select absolute top left right bottom opacity0 w-full h-full cursor-pointer "
+          data-testid="testinput-select"
+          id="testinput"
+        >
+          <option
+            value="opt1"
+          >
+            Option 1
+          </option>
+          <option
+            value="opt2"
+          >
+            Option 2
+          </option>
+        </select>
+        <div
+          class="events-none"
+        >
+          <span
+            data-testid="custom-display"
+          >
+            Custom display
+          </span>
+        </div>
       </div>
       <div
         role="alert"

--- a/src/components/control-select/__snapshots__/control-select.test.tsx.snap
+++ b/src/components/control-select/__snapshots__/control-select.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`ControlSelect all options renders 1`] = `
         </select>
         <div
           class="select-arrow"
+          data-testid="select-arrow"
         />
       </div>
       <div
@@ -111,6 +112,7 @@ exports[`ControlSelect basic renders 1`] = `
         </select>
         <div
           class="select-arrow"
+          data-testid="select-arrow"
         />
       </div>
       <div
@@ -159,6 +161,7 @@ exports[`ControlSelect disabled renders 1`] = `
         </select>
         <div
           class="select-arrow"
+          data-testid="select-arrow"
         />
       </div>
       <div
@@ -225,6 +228,7 @@ exports[`ControlSelect grouped dropdown options renders 1`] = `
         </select>
         <div
           class="select-arrow"
+          data-testid="select-arrow"
         />
       </div>
       <div
@@ -277,6 +281,7 @@ exports[`ControlSelect supported values renders 1`] = `
         </select>
         <div
           class="select-arrow"
+          data-testid="select-arrow"
         />
       </div>
       <div

--- a/src/components/control-select/control-select.test.tsx
+++ b/src/components/control-select/control-select.test.tsx
@@ -126,6 +126,56 @@ describe('ControlSelect', () => {
     });
   });
 
+  describe('with children', () => {
+    const mockOnChange = jest.fn();
+    const props = {
+      id: 'testinput',
+      options: [
+        { label: 'Option 1', value: 'opt1' },
+        { label: 'Option 2', value: 'opt2' }
+      ],
+      value: 'opt1',
+      onChange: mockOnChange,
+      children: <span data-testid="custom-display">Custom display</span>
+    };
+
+    test('renders', () => {
+      const { baseElement } = render(<ControlSelect {...props} />);
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    test('renders children content', () => {
+      render(<ControlSelect {...props} />);
+      expect(screen.getByTestId('custom-display')).toBeInTheDocument();
+    });
+
+    test('does not render the select arrow', () => {
+      const { container } = render(<ControlSelect {...props} />);
+      expect(container.querySelector('.select-arrow')).toBeNull();
+    });
+
+    test('select is invisible and positioned absolutely', () => {
+      render(<ControlSelect {...props} />);
+      const select = screen.getByTestId('testinput-select');
+      expect(select.className).toContain('absolute');
+      expect(select.className).toContain('opacity0');
+    });
+
+    test('onChange is called when an option is selected', async () => {
+      render(<ControlSelect {...props} />);
+      await userEvent.selectOptions(screen.getByTestId('testinput-select'), 'opt1');
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith('opt1', 'testinput');
+      });
+    });
+
+    test('disabled select uses cursor-default', () => {
+      render(<ControlSelect {...props} disabled={true} />);
+      const select = screen.getByTestId('testinput-select');
+      expect(select.className).toContain('cursor-default');
+    });
+  });
+
   describe('all options', () => {
     const props = {
       id: 'allOptions',

--- a/src/components/control-select/control-select.test.tsx
+++ b/src/components/control-select/control-select.test.tsx
@@ -150,8 +150,8 @@ describe('ControlSelect', () => {
     });
 
     test('does not render the select arrow', () => {
-      const { container } = render(<ControlSelect {...props} />);
-      expect(container.querySelector('.select-arrow')).toBeNull();
+      render(<ControlSelect {...props} />);
+      expect(screen.queryByTestId('select-arrow')).toBeNull();
     });
 
     test('select is invisible and positioned absolutely', () => {

--- a/src/components/control-select/control-select.tsx
+++ b/src/components/control-select/control-select.tsx
@@ -123,7 +123,7 @@ export default function ControlSelect({
         {children ? (
           <div className="events-none">{children}</div>
         ) : (
-          <div className="select-arrow" />
+          <div className="select-arrow" data-testid="select-arrow" />
         )}
       </div>
     </ControlWrapper>

--- a/src/components/control-select/control-select.tsx
+++ b/src/components/control-select/control-select.tsx
@@ -18,6 +18,7 @@ const propNames = [
   'themeControlSelectContainer',
   'themeControlWrapper',
   'themeLabel',
+  'children',
   // Passed when used with the Form component
   'initialValue',
   'validator'
@@ -44,6 +45,7 @@ interface Props {
   themeControlSelect?: string;
   themeControlWrapper?: string;
   themeLabel?: string;
+  children?: ReactNode;
 }
 
 export default function ControlSelect({
@@ -60,15 +62,20 @@ export default function ControlSelect({
   themeControlSelect = '',
   themeControlWrapper,
   themeLabel,
+  children,
   ...props
 }: Props): ReactElement {
   const extraProps = omit(props, propNames);
+
+  const selectClassName = children
+    ? `select absolute top left right bottom opacity0 w-full h-full ${disabled ? 'cursor-default' : 'cursor-pointer'} ${themeControlSelect}`
+    : `select ${themeControlSelect}`;
 
   const selectProps = {
     id,
     disabled,
     value,
-    className: `select ${themeControlSelect}`,
+    className: selectClassName,
     onChange: (e) => onChange(e.target.value, id),
     'aria-required': optional ? false : true,
     'data-testid': `${id}-select`
@@ -109,11 +116,15 @@ export default function ControlSelect({
           themeLabel={themeLabel}
         />
       )}
-      <div className={`select-container ${themeControlSelectContainer}`}>
+      <div className={`select-container ${children ? 'relative ' : ''}${themeControlSelectContainer}`.trim()}>
         <select {...selectProps} {...extraProps}>
           {options.map(renderOptions)}
         </select>
-        <div className="select-arrow" />
+        {children ? (
+          <div className="events-none">{children}</div>
+        ) : (
+          <div className="select-arrow" />
+        )}
       </div>
     </ControlWrapper>
   );
@@ -182,5 +193,7 @@ ControlSelect.propTypes = {
   /** Assembly classes to apply to the control wrapper */
   themeControlWrapper: PropTypes.string,
   /** Assembly classes to apply to the label element */
-  themeLabel: PropTypes.string
+  themeLabel: PropTypes.string,
+  /** Custom display content. When provided, the native select is hidden and positioned absolutely over this content, which is rendered with pointer-events disabled. */
+  children: PropTypes.node
 };

--- a/src/components/control-select/examples/control-select-example-children.tsx
+++ b/src/components/control-select/examples/control-select-example-children.tsx
@@ -1,0 +1,34 @@
+/*
+Custom display with children
+*/
+import React, { useState } from 'react';
+import ControlSelect from '../control-select';
+import Icon from '../../icon';
+
+const options = [
+  { label: 'Meters', value: 'meters' },
+  { label: 'Kilometers', value: 'kilometers' },
+  { label: 'Miles', value: 'miles' },
+  { label: 'Feet', value: 'feet' }
+];
+
+export default function Example() {
+  const [value, setValue] = useState('meters');
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <ControlSelect
+      id="unit"
+      options={options}
+      value={value}
+      onChange={setValue}
+    >
+      <div className="flex-parent flex-parent--center-cross btn btn--stroke btn--gray round">
+        <span className="flex-child">{selected?.label}</span>
+        <span>
+          <Icon name="caret-down" inline={true} />
+        </span>
+      </div>
+    </ControlSelect>
+  );
+}

--- a/src/components/form/__snapshots__/form.test.tsx.snap
+++ b/src/components/form/__snapshots__/form.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`Form all controls renders as expected 1`] = `
                   </label>
                 </div>
                 <div
-                  class="select-container "
+                  class="select-container"
                 >
                   <select
                     aria-required="true"
@@ -445,6 +445,7 @@ exports[`Form all controls renders as expected 1`] = `
                   </select>
                   <div
                     class="select-arrow"
+                    data-testid="select-arrow"
                   />
                 </div>
                 <div


### PR DESCRIPTION
Moving a version of this from Studio because we will need to use it in other places. Looks like this: 

<img width="1011" height="150" alt="Screenshot 2026-05-28 at 4 15 36 PM" src="https://github.com/user-attachments/assets/b04b6100-efa9-416a-8fa7-65d02e777e0b" />

This optional `children` prop gives us more stylistic control over the style select input

@badiuoanaalexandra  for review.