### PR TITLE
Update warning text color to match Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## HEAD
+
+- [fix] Update warning text from `color-orange-deep` to `color-orange-dark` to match conventions in Studio.
+
 ## 2.24.0
 
 - [feature] Add optional `children` prop to `ControlSelect`. When provided, the native select is hidden and positioned absolutely over the children, which are rendered as a custom display with pointer-events disabled.

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`Popover warning renders 1`] = `
     style="position: fixed; left: 0px; top: 0px; transform: translate(-6px, 0px); min-width: max-content; --radix-popper-transform-origin: 0px 0px; z-index: auto; --radix-popper-available-width: -16px; --radix-popper-available-height: 0px; --radix-popper-anchor-width: 0px; --radix-popper-anchor-height: 0px;"
   >
     <div
-      class="bg-orange-faint border--orange-deep color-orange-deep border shadow-darken25 round px12 py12 border border-1 border--border--orange-deep"
+      class="bg-orange-faint border--orange-deep color-orange-dark border shadow-darken25 round px12 py12 border border-1 border--border--orange-deep"
       data-align="center"
       data-side="left"
       data-state="open"

--- a/src/components/utils/styles.ts
+++ b/src/components/utils/styles.ts
@@ -88,7 +88,7 @@ function getTheme(theme?: 'dark' | 'warning' | 'error' | 'light') {
       return {
         background: 'bg-orange-faint',
         borderColor: 'border--orange-deep',
-        color: 'color-orange-deep',
+        color: 'color-orange-dark',
         fill: variables['--orange-deep'],
         shadowColor: variables['--darken25']
       };


### PR DESCRIPTION
Small change that updates warning text color from `color-orange-deep` to `color-orange-dark` to match the style editor interface. I noticed there was an inconsistency in tones. Favoring `color-orange-dark` as it is more legible for reading. 